### PR TITLE
update golangci config: exclude G107 and G501 issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -225,6 +225,8 @@ issues:
   exclude:
     - G404
     - SA1029
+    - G107
+    - G501
   # Excluding configuration per-path, per-linter, per-text and per-source
   exclude-rules:
     # Exclude some linters from running on tests files.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: 'https://github.com/golangci/golangci-lint'
-    rev: v1.33.0
+    rev: v1.34.1
     hooks:
       - id: golangci-lint
         entry: golangci-lint run


### PR DESCRIPTION
related [gosec](https://github.com/securego/gosec) linter issues:
- G107: Url provided to HTTP request as taint input
- G501: Import blocklist: crypto/md5