### PR TITLE
MOD: return value instead of reference

### DIFF
--- a/address.go
+++ b/address.go
@@ -15,18 +15,18 @@ type Syntax struct {
 }
 
 // ParseAddress attempts to parse an email address and return it in the form of an Syntax
-func (v *Verifier) ParseAddress(email string) *Syntax {
+func (v *Verifier) ParseAddress(email string) Syntax {
 
 	isAddressValid := IsAddressValid(email)
 	if !isAddressValid {
-		return &Syntax{Valid: false}
+		return Syntax{Valid: false}
 	}
 
 	index := strings.LastIndex(email, "@")
 	username := email[:index]
 	domain := strings.ToLower(email[index+1:])
 
-	return &Syntax{
+	return Syntax{
 		Username: username,
 		Domain:   domain,
 		Valid:    isAddressValid,

--- a/verifier.go
+++ b/verifier.go
@@ -21,7 +21,7 @@ type Result struct {
 	Reachable    string    `json:"reachable"`      // an enumeration to describe whether the recipient address is real
 	RoleAccount  bool      `json:"role_account"`   // is account a role-based account
 	Free         bool      `json:"free"`           // is domain a free email domain
-	Syntax       *Syntax   `json:"syntax"`         // details about the email address syntax
+	Syntax       Syntax    `json:"syntax"`         // details about the email address syntax
 	HasMxRecords bool      `json:"has_mx_records"` // whether or not MX-Records for the domain
 	SMTP         *SMTP     `json:"smtp"`           // details about the SMTP response of the email
 	Gravatar     *Gravatar `json:"gravatar"`       // whether or not have gravatar for the email

--- a/verifier_test.go
+++ b/verifier_test.go
@@ -18,7 +18,7 @@ func TestCheckEmailOK_SMTPHostNotExists(t *testing.T) {
 	ret, err := verifier.Verify(email)
 	expected := Result{
 		Email: email,
-		Syntax: &Syntax{
+		Syntax: Syntax{
 			Username: username,
 			Domain:   domain,
 			Valid:    true,
@@ -46,7 +46,7 @@ func TestCheckEmailOK_SMTPHostExists_NotCatchAll(t *testing.T) {
 	ret, err := verifier.Verify(email)
 	expected := Result{
 		Email: email,
-		Syntax: &Syntax{
+		Syntax: Syntax{
 			Username: username,
 			Domain:   domain,
 			Valid:    true,
@@ -80,7 +80,7 @@ func TestCheckEmailOK_SMTPHostExists_CatchAll(t *testing.T) {
 	ret, err := verifier.Verify(email)
 	expected := Result{
 		Email: email,
-		Syntax: &Syntax{
+		Syntax: Syntax{
 			Username: username,
 			Domain:   domain,
 			Valid:    true,
@@ -114,7 +114,7 @@ func TestCheckEmailOK_SMTPHostExists_FreeDomain(t *testing.T) {
 	ret, err := verifier.Verify(email)
 	expected := Result{
 		Email: email,
-		Syntax: &Syntax{
+		Syntax: Syntax{
 			Username: username,
 			Domain:   domain,
 			Valid:    true,
@@ -148,7 +148,7 @@ func TestCheckEmail_ErrorSyntax(t *testing.T) {
 	ret, err := verifier.Verify(email)
 	expected := Result{
 		Email: email,
-		Syntax: &Syntax{
+		Syntax: Syntax{
 			Username: username,
 			Domain:   "",
 			Valid:    false,
@@ -176,7 +176,7 @@ func TestCheckEmail_Disposable(t *testing.T) {
 	ret, err := verifier.Verify(email)
 	expected := Result{
 		Email: email,
-		Syntax: &Syntax{
+		Syntax: Syntax{
 			Username: username,
 			Domain:   domain,
 			Valid:    true,
@@ -204,7 +204,7 @@ func TestCheckEmail_RoleAccount(t *testing.T) {
 	ret, err := verifier.Verify(email)
 	expected := Result{
 		Email: email,
-		Syntax: &Syntax{
+		Syntax: Syntax{
 			Username: username,
 			Domain:   domain,
 			Valid:    true,
@@ -239,7 +239,7 @@ func TestCheckEmail_DisabledSMTPCheck(t *testing.T) {
 	ret, err := verifier.Verify(email)
 	expected := Result{
 		Email: email,
-		Syntax: &Syntax{
+		Syntax: Syntax{
 			Username: username,
 			Domain:   domain,
 			Valid:    true,


### PR DESCRIPTION
In `address.go`, `ParseAddress` return `*Syntax`, I think return value instead of reference is better for reducing GC pressure and improve memory locality.

Here is the benchmark for `return value` vs `return reference`

```
goos: linux
goarch: amd64
pkg: github.com/AfterShip/email-verifier
cpu: AMD Ryzen 7 PRO 4750G with Radeon Graphics
BenchmarkCheckAddressSyntax-16        190801       6278 ns/op      385 B/op        8 allocs/op
BenchmarkCheckAddressSyntax1-16       207202       5660 ns/op        0 B/op        0 allocs/op
PASS
```

Returning value is faster due to no memory allocation needed.

I ran `go build -gcflags='-m'` it shows a lot of `... escapes to heap`

Although it's also a matter of style, what do you think?