### PR TITLE
FIX: `IsDisposable` checks exact match domain

### DIFF
--- a/misc.go
+++ b/misc.go
@@ -22,7 +22,6 @@ func (v *Verifier) IsFreeDomain(domain string) bool {
 // IsDisposable checks if domain is a disposable domain
 func (v *Verifier) IsDisposable(domain string) bool {
 	domain = domainToASCII(domain)
-	d := parsedDomain(domain)
-	_, found := disposableSyncDomains.Load(d)
+	_, found := disposableSyncDomains.Load(domain)
 	return found
 }


### PR DESCRIPTION
Here is a bug, because the disposable domain check is based on the [exact match pattern](https://github.com/ivolo/disposable-email-domains), so it no longer does fuzzy matching