### PR TITLE
Test: update catch-all related test cases

### DIFF
--- a/smtp_test.go
+++ b/smtp_test.go
@@ -23,13 +23,13 @@ func TestCheckSMTPOK_HostExists(t *testing.T) {
 }
 
 func TestCheckSMTPOK_CatchAllHost(t *testing.T) {
-	domain := "yahoo.com"
+	domain := "gmail.com"
 
 	smtp, err := verifier.CheckSMTP(domain, "")
 	expected := SMTP{
 		HostExists: true,
 		FullInbox:  false,
-		CatchAll:   true,
+		CatchAll:   false,
 		Disabled:   false,
 	}
 	assert.NoError(t, err)

--- a/smtp_test.go
+++ b/smtp_test.go
@@ -118,8 +118,8 @@ func TestNewSMTPClientFailed_WithInvalidProxy(t *testing.T) {
 }
 
 func TestNewSMTPClientFailed(t *testing.T) {
-	disposableDomain := "zzzz1717.com"
-	ret, err := newSMTPClient(disposableDomain, "")
+	domain := "zzzz171777.com"
+	ret, err := newSMTPClient(domain, "")
 	assert.Nil(t, ret)
 	assert.Error(t, err)
 	assert.True(t, strings.Contains(err.Error(), "no such host"))

--- a/verifier_test.go
+++ b/verifier_test.go
@@ -68,40 +68,6 @@ func TestCheckEmailOK_SMTPHostExists_NotCatchAll(t *testing.T) {
 	assert.Equal(t, &expected, ret)
 }
 
-func TestCheckEmailOK_SMTPHostExists_CatchAll(t *testing.T) {
-	var (
-		// trueVal  = true
-		username = "email_username"
-		domain   = "yahoo.com"
-		address  = username + "@" + domain
-		email    = address
-	)
-
-	ret, err := verifier.Verify(email)
-	expected := Result{
-		Email: email,
-		Syntax: Syntax{
-			Username: username,
-			Domain:   domain,
-			Valid:    true,
-		},
-		HasMxRecords: true,
-		Reachable:    reachableUnknown,
-		Disposable:   false,
-		RoleAccount:  false,
-		Free:         true,
-		SMTP: &SMTP{
-			HostExists:  true,
-			FullInbox:   false,
-			CatchAll:    true,
-			Deliverable: false,
-			Disabled:    false,
-		},
-	}
-	assert.Nil(t, err)
-	assert.Equal(t, &expected, ret)
-}
-
 func TestCheckEmailOK_SMTPHostExists_FreeDomain(t *testing.T) {
 	var (
 		// trueVal  = true
@@ -192,7 +158,6 @@ func TestCheckEmail_Disposable(t *testing.T) {
 	assert.Equal(t, &expected, ret)
 }
 
-
 func TestCheckEmail_Disposable_override(t *testing.T) {
 	var (
 		username = "exampleuser"
@@ -220,7 +185,6 @@ func TestCheckEmail_Disposable_override(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, &expected, ret)
 }
-
 
 func TestCheckEmail_RoleAccount(t *testing.T) {
 	var (


### PR DESCRIPTION
 For IP is permanently deferred by  yahoo, and yahoo.com is not a catch-all domain actually.