### PR TITLE
return HasMXRecord as true when at least one valid mx records exist

### DIFF
--- a/mx.go
+++ b/mx.go
@@ -12,8 +12,8 @@ type Mx struct {
 func (v *Verifier) CheckMX(domain string) (*Mx, error) {
 	domain = domainToASCII(domain)
 	mx, err := net.LookupMX(domain)
-	if err != nil {
-		return nil, ParseSMTPError(err)
+	if err != nil && len(mx) == 0 {
+		return nil, err
 	}
 	return &Mx{
 		HasMXRecord: len(mx) > 0,


### PR DESCRIPTION
Some domains may have several MX records and some of them may be invalid
for example nslookup for the domain `test-unicode.definbox.com` returns "some" valid MX records

I think we should return True in cases when at least one MX record exist and is valid.

Currently the library will return `has_mx_records = False` in this case although I think this is incorrect behavior
Inside the Go library, they made changes to support this case 
https://github.com/golang/go/blob/dd96ded6c86b8a38f49fa087b758455243a0f08c/src/net/lookup.go#L515

some additional references:
https://go-review.googlesource.com/c/go/+/333331
https://github.com/golang/go/issues/46979

I wanted to add a relevant test but if the tests are actually performing the MX check, if the DNS record is fixed in those domains the test will fail, making it unstable.
Any thoughts?



