### PR TITLE
Update Verify() with goroutine to speed up the request and some minor changes

### DIFF
--- a/gravatar.go
+++ b/gravatar.go
@@ -18,7 +18,7 @@ type Gravatar struct {
 func (v *Verifier) CheckGravatar(email string) (*Gravatar, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	err, emailMd5 := getMD5Hash(strings.ToLower(strings.TrimSpace(email)))
+	emailMd5, err := getMD5Hash(strings.ToLower(strings.TrimSpace(email)))
 	if err != nil {
 		return nil, err
 	}
@@ -41,7 +41,7 @@ func (v *Verifier) CheckGravatar(email string) (*Gravatar, error) {
 		return nil, err
 	}
 	// check body
-	err, md5Body := getMD5Hash(string(body))
+	md5Body, err := getMD5Hash(string(body))
 	if err != nil {
 		return nil, err
 	}

--- a/smtp.go
+++ b/smtp.go
@@ -29,7 +29,7 @@ type SMTP struct {
 //
 // if server is catch-all server, username will not be checked
 func (v *Verifier) CheckSMTP(domain, username string) (*SMTP, error) {
-	if !v.smtpCheckEnabled {
+	if !v.SmtpCheckEnabled {
 		return nil, nil
 	}
 
@@ -69,7 +69,7 @@ func (v *Verifier) CheckSMTP(domain, username string) (*SMTP, error) {
 	// Default sets catch-all to true
 	ret.CatchAll = true
 
-	if v.catchAllCheckEnabled {
+	if v.CatchAllCheckEnabled {
 		// Checks the deliver ability of a randomly generated address in
 		// order to verify the existence of a catch-all and etc.
 		randomEmail := GenerateRandomEmail(domain)

--- a/util.go
+++ b/util.go
@@ -49,11 +49,11 @@ func callJobFuncWithParams(jobFunc interface{}, params []interface{}) []reflect.
 
 // getMD5Hash use md5 to encode string
 // #nosec
-func getMD5Hash(str string) (error, string) {
+func getMD5Hash(str string) (string, error) {
 	h := md5.New()
 	_, err := h.Write([]byte(str))
 	if err != nil {
-		return err, ""
+		return "", err
 	}
-	return nil, hex.EncodeToString(h.Sum(nil))
+	return hex.EncodeToString(h.Sum(nil)), nil
 }

--- a/verifier_test.go
+++ b/verifier_test.go
@@ -292,3 +292,29 @@ func TestCheckEmail_EnableDomainSuggest(t *testing.T) {
 
 	assert.Equal(t, ret.Suggestion, "")
 }
+
+func TestVerify_ValidNonDisposableEmail(t *testing.T) {
+	// Arrange
+	var (
+		username = "validuser"
+		domain   = "non-disposable.com"
+		email    = username + "@" + domain
+	)
+
+	verifier := NewVerifier()
+	result, err := verifier.Verify(email)
+	assert.NoError(t, err)
+
+	expected := &Result{
+		Email:     email,
+		Reachable: reachableUnknown,
+		Syntax: Syntax{
+			Username: username,
+			Domain:   domain,
+			Valid:    true,
+		},
+		Disposable: false,
+	}
+
+	assert.Equal(t, expected, result)
+}


### PR DESCRIPTION
### Updates

- Changed the `getMD5Hash()` return order
- Changed the struct's Verifier to make the enablers accessible outside the package
- Added goroutine channels inside `Verify()` to speed up the request.
   - in-addition I've added Verifier.VerifyTimeout to control the timeout (2seconds is already battle tested in fly.io using shared1x256)