### PR TITLE
fix: reachable should no when SMTP host not exists

### DIFF
--- a/verifier.go
+++ b/verifier.go
@@ -84,6 +84,11 @@ func (v *Verifier) Verify(email string) (*Result, error) {
 
 	mx, err := v.CheckMX(syntax.Domain)
 	if err != nil {
+		errStr := err.Error()
+		if insContains(errStr, "no such host") {
+			ret.Reachable = reachableNo
+			return &ret, newLookupError(ErrNoSuchHost, errStr)
+		}
 		return &ret, err
 	}
 	ret.HasMxRecords = mx.HasMXRecord

--- a/verifier_test.go
+++ b/verifier_test.go
@@ -26,11 +26,11 @@ func TestCheckEmailOK_SMTPHostNotExists(t *testing.T) {
 		HasMxRecords: false,
 		Disposable:   false,
 		RoleAccount:  false,
-		Reachable:    reachableUnknown,
+		Reachable:    reachableNo,
 		Free:         false,
 		SMTP:         nil,
 	}
-	assert.Error(t, err, ErrNoSuchHost)
+	assert.ErrorContains(t, err, ErrNoSuchHost)
 	assert.Equal(t, &expected, ret)
 }
 


### PR DESCRIPTION
This PR sets `ret.Reachable` to `reachableNo` and returns `ErrNoSuchHost` when `CheckMX` returns the error `...no such host...`