### PR TITLE
fix: execute suggestion when domain is known

### DIFF
--- a/verifier.go
+++ b/verifier.go
@@ -76,6 +76,9 @@ func (v *Verifier) Verify(email string) (*Result, error) {
 	ret.Free = v.IsFreeDomain(syntax.Domain)
 	ret.RoleAccount = v.IsRoleAccount(syntax.Username)
 	ret.Disposable = v.IsDisposable(syntax.Domain)
+	if v.domainSuggestEnabled {
+		ret.Suggestion = v.SuggestDomain(syntax.Domain)
+	}
 
 	// If the domain name is disposable, mx and smtp are not checked.
 	if ret.Disposable {
@@ -101,10 +104,6 @@ func (v *Verifier) Verify(email string) (*Result, error) {
 			return &ret, err
 		}
 		ret.Gravatar = gravatar
-	}
-
-	if v.domainSuggestEnabled {
-		ret.Suggestion = v.SuggestDomain(syntax.Domain)
 	}
 
 	return &ret, nil

--- a/verifier_test.go
+++ b/verifier_test.go
@@ -283,12 +283,12 @@ func TestCheckEmail_EnableDomainSuggest(t *testing.T) {
 	var (
 		// trueVal  = true
 		username = "email_username"
-		domain   = "hotmail.com"
+		domain   = "gmai.com"
 		address  = username + "@" + domain
 		email    = address
 	)
 
-	ret, _ := verifier.Verify(email)
+	ret, _ := verifier.EnableDomainSuggest().Verify(email)
 
-	assert.Equal(t, ret.Suggestion, "")
+	assert.Equal(t, ret.Suggestion, "gmail.com")
 }


### PR DESCRIPTION
Currently, `SuggestDomain` in `Verify` is executed last, which causes the suggestion to return as `""` when an error is encountered earlier, and `SuggestDomain` should be executed as soon as possible

close: #101