### PR TITLE
Add Optional MX Lookup Cache for Enhanced Bulk Email Verification

### DIFF
--- a/misc_test.go
+++ b/misc_test.go
@@ -2,11 +2,12 @@ package emailverifier
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
-var verifier = NewVerifier().EnableSMTPCheck()
+var verifier = NewVerifier().EnableSMTPCheck().EnableMXCache(1 * time.Hour)
 
 func TestIsFreeDomain_True(t *testing.T) {
 	domain := "gmail.com"

--- a/mx.go
+++ b/mx.go
@@ -1,6 +1,8 @@
 package emailverifier
 
-import "net"
+import (
+	"net"
+)
 
 // Mx is detail about the Mx host
 type Mx struct {
@@ -9,9 +11,18 @@ type Mx struct {
 }
 
 // CheckMX will return the DNS MX records for the given domain name sorted by preference.
-func (v *Verifier) CheckMX(domain string) (*Mx, error) {
+func (v *Verifier) CheckMX(domain string, useCache bool) (*Mx, error) {
 	domain = domainToASCII(domain)
-	mx, err := net.LookupMX(domain)
+
+	var mx []*net.MX
+	var err error
+	
+	lookup := net.LookupMX
+	if useCache {
+		lookup = v.mxCache.Get
+	}
+	mx, err = lookup(domain)
+
 	if err != nil && len(mx) == 0 {
 		return nil, err
 	}

--- a/mx_cache.go
+++ b/mx_cache.go
@@ -1,0 +1,82 @@
+package emailverifier
+
+import (
+	"net"
+	"sync"
+	"time"
+)
+
+// MXCache represents a thread-safe cache for MX records
+type MXCache struct {
+	sync.RWMutex
+	records map[string]cacheEntry
+	ttl     time.Duration
+}
+
+type cacheEntry struct {
+	mxRecords []*net.MX
+	expiry    time.Time
+}
+
+type GetMXFunc func(domain string) ([]*net.MX, error)
+
+// NewMXCache creates and initializes a new MX cache and starts the cleanup goroutine
+func NewMXCache(ttl time.Duration) *MXCache {
+	cache := &MXCache{
+		records: make(map[string]cacheEntry),
+		ttl:     ttl,
+	}
+
+	// Start the cleanup process with a 15-minute interval
+	cache.StartCleanup(15 * time.Minute)
+
+	return cache
+}
+
+// Get retrieves MX records for a domain from cache or performs a lookup
+func (c *MXCache) Get(domain string) ([]*net.MX, error) {
+	asciiDomain := domainToASCII(domain)
+
+	// Check cache first
+	c.RLock()
+	if entry, exists := c.records[asciiDomain]; exists {
+		if time.Now().Before(entry.expiry) {
+			c.RUnlock()
+			return entry.mxRecords, nil
+		}
+	}
+	c.RUnlock()
+
+	// Perform actual lookup if not in cache or expired
+	mxRecords, err := net.LookupMX(asciiDomain)
+	if err != nil {
+		return nil, err
+	}
+
+	// Update cache
+	c.Lock()
+	c.records[asciiDomain] = cacheEntry{
+		mxRecords: mxRecords,
+		expiry:    time.Now().Add(c.ttl),
+	}
+	c.Unlock()
+
+	return mxRecords, nil
+}
+
+// StartCleanup initiates periodic cleanup of expired cache entries
+func (c *MXCache) StartCleanup(interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	go func() {
+		for range ticker.C {
+			c.Lock()
+			now := time.Now()
+			for domain, entry := range c.records {
+				if now.After(entry.expiry) {
+					delete(c.records, domain)
+				}
+			}
+			c.Unlock()
+		}
+	}()
+}

--- a/mx_cache_test.go
+++ b/mx_cache_test.go
@@ -6,18 +6,18 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCheckMxOK(t *testing.T) {
+func TestCheckMxWithCacheOK(t *testing.T) {
 	domain := "github.com"
 
-	mx, err := verifier.CheckMX(domain, false)
+	mx, err := verifier.CheckMX(domain, true)
 	assert.NoError(t, err)
 	assert.True(t, mx.HasMXRecord)
 }
 
-func TestCheckNoMxOK(t *testing.T) {
+func TestCheckNoMxWithCacheOK(t *testing.T) {
 	domain := "githubexists.com"
 
-	mx, err := verifier.CheckMX(domain, false)
+	mx, err := verifier.CheckMX(domain, true)
 	assert.Nil(t, mx)
 	assert.Error(t, err, ErrNoSuchHost)
 }

--- a/smtp_test.go
+++ b/smtp_test.go
@@ -1,6 +1,7 @@
 package emailverifier
 
 import (
+	"net"
 	"strings"
 	"syscall"
 	"testing"
@@ -196,7 +197,8 @@ func TestCheckSMTPOK_HostNotExists(t *testing.T) {
 func TestNewSMTPClientOK(t *testing.T) {
 	domain := "gmail.com"
 	timeout := 5 * time.Second
-	ret, _, err := newSMTPClient(domain, "", timeout, timeout)
+	var getMx GetMXFunc = net.LookupMX
+	ret, _, err := newSMTPClient(domain, "", timeout, timeout, getMx)
 	assert.NotNil(t, ret)
 	assert.Nil(t, err)
 }
@@ -205,7 +207,8 @@ func TestNewSMTPClientFailed_WithInvalidProxy(t *testing.T) {
 	domain := "gmail.com"
 	proxyURI := "socks5://user:password@127.0.0.1:1080?timeout=5s"
 	timeout := 5 * time.Second
-	ret, _, err := newSMTPClient(domain, proxyURI, timeout, timeout)
+	var getMx GetMXFunc = net.LookupMX
+	ret, _, err := newSMTPClient(domain, proxyURI, timeout, timeout, getMx)
 	assert.Nil(t, ret)
 	assert.Error(t, err, syscall.ECONNREFUSED)
 }
@@ -213,7 +216,8 @@ func TestNewSMTPClientFailed_WithInvalidProxy(t *testing.T) {
 func TestNewSMTPClientFailed(t *testing.T) {
 	domain := "zzzz171777.com"
 	timeout := 5 * time.Second
-	ret, _, err := newSMTPClient(domain, "", timeout, timeout)
+	var getMx GetMXFunc = net.LookupMX
+	ret, _, err := newSMTPClient(domain, "", timeout, timeout, getMx)
 	assert.Nil(t, ret)
 	assert.Error(t, err)
 }

--- a/verifier.go
+++ b/verifier.go
@@ -12,6 +12,8 @@ type Verifier struct {
 	catchAllCheckEnabled bool                       // SMTP catchAll check enabled or disabled (enabled by default)
 	domainSuggestEnabled bool                       // whether suggest a most similar correct domain or not (disabled by default)
 	gravatarCheckEnabled bool                       // gravatar check enabled or disabled (disabled by default)
+	mxCacheEnabled       bool                       // MX cache enabled or disabled (disabled by default)
+	mxCache              *MXCache                   // MX cache
 	fromEmail            string                     // name to use in the `EHLO:` SMTP command, defaults to "user@example.org"
 	helloName            string                     // email to use in the `MAIL FROM:` SMTP command. defaults to `localhost`
 	schedule             *schedule                  // schedule represents a job schedule
@@ -82,7 +84,7 @@ func (v *Verifier) Verify(email string) (*Result, error) {
 		return &ret, nil
 	}
 
-	mx, err := v.CheckMX(syntax.Domain)
+	mx, err := v.CheckMX(syntax.Domain, v.mxCacheEnabled)
 	if err != nil {
 		return &ret, err
 	}
@@ -205,6 +207,19 @@ func (v *Verifier) DisableAutoUpdateDisposable() *Verifier {
 	v.stopCurrentSchedule()
 	return v
 
+}
+
+// EnableMXCache enables cache for MX records
+func (v *Verifier) EnableMXCache(ttl time.Duration) *Verifier {
+	v.mxCache = NewMXCache(ttl)
+	v.mxCacheEnabled = true
+	return v
+}
+
+// DisableMXCache disables cache for MX records
+func (v *Verifier) DisableMXCache() *Verifier {
+	v.mxCacheEnabled = false
+	return v
 }
 
 // FromEmail sets the emails to use in the `MAIL FROM:` smtp command


### PR DESCRIPTION
### Features
- Optional MX Lookup Cache: Disabled by default. Enable it by calling emailverifier.NewVerifier().EnableMXCache(1 * time.Hour).
- Custom TTL: Allows setting a custom Time-To-Live (TTL) for cached MX records.
- Automatic Cleanup: Runs a background ticker to remove expired cache records automatically.


### Benefit
- Resource Efficiency: Decreases DNS server load by reusing cached MX records.

Feel free to review and let me know if there are any adjustments needed!
close #142 