### PR TITLE
chore: return error as last argument

### DIFF
--- a/gravatar.go
+++ b/gravatar.go
@@ -18,7 +18,7 @@ type Gravatar struct {
 func (v *Verifier) CheckGravatar(email string) (*Gravatar, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	err, emailMd5 := getMD5Hash(strings.ToLower(strings.TrimSpace(email)))
+	emailMd5, err := getMD5Hash(strings.ToLower(strings.TrimSpace(email)))
 	if err != nil {
 		return nil, err
 	}
@@ -41,7 +41,7 @@ func (v *Verifier) CheckGravatar(email string) (*Gravatar, error) {
 		return nil, err
 	}
 	// check body
-	err, md5Body := getMD5Hash(string(body))
+	md5Body, err := getMD5Hash(string(body))
 	if err != nil {
 		return nil, err
 	}

--- a/util.go
+++ b/util.go
@@ -49,11 +49,11 @@ func callJobFuncWithParams(jobFunc interface{}, params []interface{}) []reflect.
 
 // getMD5Hash use md5 to encode string
 // #nosec
-func getMD5Hash(str string) (error, string) {
+func getMD5Hash(str string) (string, error) {
 	h := md5.New()
 	_, err := h.Write([]byte(str))
 	if err != nil {
-		return err, ""
+		return "", err
 	}
-	return nil, hex.EncodeToString(h.Sum(nil))
+	return hex.EncodeToString(h.Sum(nil)), nil
 }


### PR DESCRIPTION
Change the return arguments order of `getMD5Hash` function 
to follow Go's standard convention where the error is the last return value.