### PR TITLE
adding Enable/DisableMXCheck() option

### DIFF
--- a/mx.go
+++ b/mx.go
@@ -10,6 +10,12 @@ type Mx struct {
 
 // CheckMX will return the DNS MX records for the given domain name sorted by preference.
 func (v *Verifier) CheckMX(domain string) (*Mx, error) {
+	if !v.mxCheckEnabled {
+		return &Mx{
+			HasMXRecord: false,
+		}, nil
+	}
+
 	domain = domainToASCII(domain)
 	mx, err := net.LookupMX(domain)
 	if err != nil && len(mx) == 0 {

--- a/verifier.go
+++ b/verifier.go
@@ -8,6 +8,7 @@ import (
 
 // Verifier is an email verifier. Create one by calling NewVerifier
 type Verifier struct {
+	mxCheckEnabled       bool                       // MX record check enabled or disabled (enabled by default)
 	smtpCheckEnabled     bool                       // SMTP check enabled or disabled (disabled by default)
 	catchAllCheckEnabled bool                       // SMTP catchAll check enabled or disabled (enabled by default)
 	domainSuggestEnabled bool                       // whether suggest a most similar correct domain or not (disabled by default)
@@ -50,6 +51,7 @@ func init() {
 // NewVerifier creates a new email verifier
 func NewVerifier() *Verifier {
 	return &Verifier{
+		mxCheckEnabled:       true,
 		fromEmail:            defaultFromEmail,
 		helloName:            defaultHelloName,
 		catchAllCheckEnabled: true,
@@ -164,6 +166,19 @@ func (v *Verifier) DisableAPIVerifier(name string) {
 // DisableSMTPCheck disables check email by smtp
 func (v *Verifier) DisableSMTPCheck() *Verifier {
 	v.smtpCheckEnabled = false
+	return v
+}
+
+// EnableMXCheck enables MX record check by dns,
+// we check MX record by default
+func (v *Verifier) EnableMXCheck() *Verifier {
+	v.mxCheckEnabled = true
+	return v
+}
+
+// DisableMXCheck disables MX record check by dns
+func (v *Verifier) DisableMXCheck() *Verifier {
+	v.mxCheckEnabled = false
 	return v
 }
 

--- a/verifier_test.go
+++ b/verifier_test.go
@@ -250,6 +250,36 @@ func TestCheckEmail_DisabledSMTPCheck(t *testing.T) {
 	assert.Equal(t, &expected, ret)
 }
 
+func TestCheckEmail_DisabledMXCheck(t *testing.T) {
+	var (
+		// trueVal  = true
+		username = "email_username"
+		domain   = "randomain.com"
+		address  = username + "@" + domain
+		email    = address
+	)
+
+	verifier := NewVerifier().DisableMXCheck()
+	ret, err := verifier.Verify(email)
+	expected := Result{
+		Email: email,
+		Syntax: Syntax{
+			Username: username,
+			Domain:   domain,
+			Valid:    true,
+		},
+		HasMxRecords: false,
+		Disposable:   false,
+		RoleAccount:  false,
+		Reachable:    reachableUnknown,
+		Free:         false,
+		SMTP:         nil,
+	}
+	verifier.EnableSMTPCheck()
+	assert.NoError(t, err)
+	assert.Equal(t, &expected, ret)
+}
+
 func TestNewVerifierOK_AutoUpdateDisposable(t *testing.T) {
 	verifier.EnableAutoUpdateDisposable()
 }

--- a/verifier_test.go
+++ b/verifier_test.go
@@ -275,7 +275,6 @@ func TestCheckEmail_DisabledMXCheck(t *testing.T) {
 		Free:         false,
 		SMTP:         nil,
 	}
-	verifier.EnableSMTPCheck()
 	assert.NoError(t, err)
 	assert.Equal(t, &expected, ret)
 }


### PR DESCRIPTION
Adding `EnableMXCheck()` and `DisableMXCheck()` using `mxCheckEnabled` .

It is enabled by default to keep existing behavior.

Code for Issue #92 