### PR TITLE
fix(test): stop Yahoo API test panic from aborting the whole suite

### DIFF
--- a/smtp_by_api_yahoo_test.go
+++ b/smtp_by_api_yahoo_test.go
@@ -13,14 +13,14 @@ func TestYahooCheckByAPI(t *testing.T) {
 	t.Run("email exists", func(tt *testing.T) {
 		res, err := yahooAPIVerifier.check("yahoo.com", "hello")
 		require.NoError(tt, err)
-		assert.Equal(tt, true, res.HostExists)
-		assert.Equal(tt, true, res.Deliverable)
+		assert.True(tt, res.HostExists)
+		assert.True(tt, res.Deliverable)
 	})
 	t.Run("invalid email not exists", func(tt *testing.T) {
 		res, err := yahooAPIVerifier.check("yahoo.com", "123")
 		require.NoError(tt, err)
-		assert.Equal(tt, true, res.HostExists)
-		assert.Equal(tt, false, res.Deliverable)
+		assert.True(tt, res.HostExists)
+		assert.False(tt, res.Deliverable)
 	})
 }
 

--- a/smtp_by_api_yahoo_test.go
+++ b/smtp_by_api_yahoo_test.go
@@ -5,21 +5,22 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestYahooCheckByAPI(t *testing.T) {
 	yahooAPIVerifier := newYahooAPIVerifier(nil)
 	t.Run("email exists", func(tt *testing.T) {
 		res, err := yahooAPIVerifier.check("yahoo.com", "hello")
-		assert.NoError(t, err)
-		assert.Equal(t, true, res.HostExists)
-		assert.Equal(t, true, res.Deliverable)
+		require.NoError(tt, err)
+		assert.Equal(tt, true, res.HostExists)
+		assert.Equal(tt, true, res.Deliverable)
 	})
 	t.Run("invalid email not exists", func(tt *testing.T) {
 		res, err := yahooAPIVerifier.check("yahoo.com", "123")
-		assert.NoError(t, err)
-		assert.Equal(t, true, res.HostExists)
-		assert.Equal(t, false, res.Deliverable)
+		require.NoError(tt, err)
+		assert.Equal(tt, true, res.HostExists)
+		assert.Equal(tt, false, res.Deliverable)
 	})
 }
 


### PR DESCRIPTION
## Problem

`TestYahooCheckByAPI` uses `assert.NoError`, which records a failure but does not halt. When
`check()` returns an error, execution continues to `res.HostExists` with `res == nil` and
panics, which kills the test binary.

That test is **#44 of ~90** in the package, so every test after it stops running. Since the
upstream Yahoo endpoint broke around 2025-12-09 (see #195), the following have not executed in
CI for ~8.5 months:

- all of `smtp_test.go` — every SMTP and catch-all test
- all of `suggestion_test.go`
- all of `util_test.go`
- all of `verifier_test.go`

Every `ci.yml` run since 2025-12-09 has failed, and the panic meant the reported failure told
you about one test while silently hiding 47 others.

## Change

One file, two commits. `require.NoError` instead of `assert.NoError`, pass the subtest's own
`*testing.T`, and switch the bool comparisons to `assert.True`/`assert.False`:

- **`require` instead of `assert`** — fails the subtest immediately rather than continuing on
  to dereference a nil `*SMTP`.
- **`tt` instead of `t`** — the closure parameter was declared but never used (legal for
  parameters, so it compiled), so assertions were attributed to the parent test. It also
  matters for `require`: `FailNow` must be called from the goroutine running the test, and
  subtests run in their own.
- **`assert.True`/`assert.False`** — `testifylint`'s `bool-compare` rule rejects
  `assert.Equal(tt, true, x)`. Those lines already violated it, but `only-new-issues: true`
  meant it was never surfaced until this branch touched them.

## Verification

Run locally with the same flags CI uses, `go test -race -covermode atomic ./...`:

| | before | after |
|---|---|---|
| outcome | panic at test #44 | suite completes, 27.4s |
| tests never executed | 47 | 0 |
| failures | 1 reported, 47 hidden | 2, both explained |

The two remaining failures share one root cause — `yahoo check by api, no sessionIndex`:

- `TestYahooCheckByAPI`
- `TestCheckSMTPOK_ByApi` (`smtp_test.go:67`, which goes through `EnableAPIVerifier(YAHOO)`;
  it never panicked only because it does not dereference the nil result)

Spot-checked that the previously-dead tests genuinely pass rather than merely run: a targeted
run over `verifier_test.go`, `smtp_test.go`, `suggestion_test.go` and `util_test.go` gives 21
passes and `ok`.

Confirmed on CI as well — the run on this branch reaches the Test step, completes in 11.7s
with no panic, and reports those same two failures and nothing else. So the SMTP tests in
`smtp_test.go` do pass on GitHub's runners; they had simply not been reached since December.

## Scope

**This does not make CI green.** The two tests above will keep failing until there is a
decision on the Yahoo verifier itself — #195 lays out the options (remove it following the
Gmail precedent in #113, chase Yahoo's replacement endpoint, or give `catch_all` a way to
express "undetermined"). That decision is deliberately out of scope here, since removing
`EnableAPIVerifier(YAHOO)` would be a breaking public API change.

What this does do is restore CI signal for the other 88 tests, so unrelated PRs stop carrying
a red check that hides whether they actually broke anything. #188 is a current example — the
test it adds lives in `verifier_test.go` and has never executed.

Refs #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)
