### PR TITLE
test: isolate live SMTP integration checks

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -1,0 +1,16 @@
+package emailverifier
+
+import (
+	"os"
+	"testing"
+)
+
+// requireLiveNetwork keeps unit-test runs independent from third-party services
+// and from networks that block outbound SMTP. Set EMAIL_VERIFIER_INTEGRATION=1
+// to run the live integration checks explicitly.
+func requireLiveNetwork(t *testing.T) {
+	t.Helper()
+	if os.Getenv("EMAIL_VERIFIER_INTEGRATION") != "1" {
+		t.Skip("live network test; set EMAIL_VERIFIER_INTEGRATION=1 to run")
+	}
+}

--- a/smtp_by_api_yahoo_test.go
+++ b/smtp_by_api_yahoo_test.go
@@ -1,7 +1,9 @@
 package emailverifier
 
 import (
+	"io"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,7 +11,30 @@ import (
 )
 
 func TestYahooCheckByAPI(t *testing.T) {
-	yahooAPIVerifier := newYahooAPIVerifier(nil)
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		resp := &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Request:    req,
+		}
+		switch req.Method {
+		case http.MethodGet:
+			resp.Header.Add("Set-Cookie", "AS=v=1&s=test-acrumb&d=value; Path=/")
+			resp.Body = io.NopCloser(strings.NewReader(`<input value="test-session" name="sessionIndex">`))
+		case http.MethodPost:
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				return nil, err
+			}
+			if strings.Contains(string(body), `"userId":"hello"`) {
+				resp.Body = io.NopCloser(strings.NewReader(`{"errors":[{"name":"userId","error":"IDENTIFIER_EXISTS"}]}`))
+			} else {
+				resp.Body = io.NopCloser(strings.NewReader(`{"errors":[]}`))
+			}
+		}
+		return resp, nil
+	})}
+	yahooAPIVerifier := newYahooAPIVerifier(client)
 	t.Run("email exists", func(tt *testing.T) {
 		res, err := yahooAPIVerifier.check("yahoo.com", "hello")
 		require.NoError(tt, err)
@@ -22,6 +47,12 @@ func TestYahooCheckByAPI(t *testing.T) {
 		assert.True(tt, res.HostExists)
 		assert.False(tt, res.Deliverable)
 	})
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
 }
 
 func TestGetAcrumb(t *testing.T) {

--- a/smtp_test.go
+++ b/smtp_test.go
@@ -15,6 +15,7 @@ func TestCheckSMTPUnSupportedVendor(t *testing.T) {
 }
 
 func TestCheckSMTPOK_ByApi(t *testing.T) {
+	requireLiveNetwork(t)
 	cases := []struct {
 		name     string
 		domain   string
@@ -71,6 +72,7 @@ func TestCheckSMTPOK_ByApi(t *testing.T) {
 }
 
 func TestCheckSMTPOK_HostExists(t *testing.T) {
+	requireLiveNetwork(t)
 	domain := "github.com"
 
 	smtp, err := verifier.CheckSMTP(domain, "")
@@ -85,6 +87,7 @@ func TestCheckSMTPOK_HostExists(t *testing.T) {
 }
 
 func TestCheckSMTPOK_CatchAllHost(t *testing.T) {
+	requireLiveNetwork(t)
 	domain := "gmail.com"
 
 	smtp, err := verifier.CheckSMTP(domain, "")
@@ -99,6 +102,7 @@ func TestCheckSMTPOK_CatchAllHost(t *testing.T) {
 }
 
 func TestCheckSMTPOK_NoCatchAllHost(t *testing.T) {
+	requireLiveNetwork(t)
 	domain := "gmail.com"
 
 	smtp, err := verifier.CheckSMTP(domain, "")
@@ -113,6 +117,7 @@ func TestCheckSMTPOK_NoCatchAllHost(t *testing.T) {
 }
 
 func TestCheckSMTPOK_NoCatchAllHostCatchAllCheckDisabled(t *testing.T) {
+	requireLiveNetwork(t)
 	domain := "gmail.com"
 
 	var verifier = NewVerifier().EnableSMTPCheck().DisableCatchAllCheck()
@@ -128,6 +133,7 @@ func TestCheckSMTPOK_NoCatchAllHostCatchAllCheckDisabled(t *testing.T) {
 }
 
 func TestCheckSMTPOK_UpdateFromEmail(t *testing.T) {
+	requireLiveNetwork(t)
 	domain := "github.com"
 	verifier.FromEmail("from@email.top")
 
@@ -144,6 +150,7 @@ func TestCheckSMTPOK_UpdateFromEmail(t *testing.T) {
 }
 
 func TestCheckSMTPOK_UpdateHelloName(t *testing.T) {
+	requireLiveNetwork(t)
 	domain := "github.com"
 	verifier.HelloName("email.top")
 
@@ -160,6 +167,7 @@ func TestCheckSMTPOK_UpdateHelloName(t *testing.T) {
 }
 
 func TestCheckSMTPOK_WithNoExistUsername(t *testing.T) {
+	requireLiveNetwork(t)
 	domain := "github.com"
 	username := "testing"
 
@@ -194,6 +202,7 @@ func TestCheckSMTPOK_HostNotExists(t *testing.T) {
 }
 
 func TestNewSMTPClientOK(t *testing.T) {
+	requireLiveNetwork(t)
 	domain := "gmail.com"
 	timeout := 5 * time.Second
 	ret, _, err := newSMTPClient(domain, "", timeout, timeout)

--- a/verifier_test.go
+++ b/verifier_test.go
@@ -35,6 +35,7 @@ func TestCheckEmailOK_SMTPHostNotExists(t *testing.T) {
 }
 
 func TestCheckEmailOK_SMTPHostExists_NotCatchAll(t *testing.T) {
+	requireLiveNetwork(t)
 	var (
 		// trueVal  = true
 		username = "email_username"
@@ -69,6 +70,7 @@ func TestCheckEmailOK_SMTPHostExists_NotCatchAll(t *testing.T) {
 }
 
 func TestCheckEmailOK_SMTPHostExists_FreeDomain(t *testing.T) {
+	requireLiveNetwork(t)
 	var (
 		// trueVal  = true
 		username = "email_username"
@@ -187,6 +189,7 @@ func TestCheckEmail_Disposable_override(t *testing.T) {
 }
 
 func TestCheckEmail_RoleAccount(t *testing.T) {
+	requireLiveNetwork(t)
 	var (
 		// trueVal  = true
 		username = "admin"


### PR DESCRIPTION
Isolates live SMTP integration tests from the regular test suite to avoid failures caused by external network conditions and SMTP server availability.

This makes the default test suite more deterministic and reliable while keeping the live SMTP checks available for explicit integration testing.

## Changes

- Isolate tests that depend on live SMTP servers
- Prevent external network failures from breaking the default test suite
- Keep live SMTP behavior testable separately
- Replace the live Yahoo verifier test dependency with a deterministic mocked HTTP client

## Testing

- Ran the default test suite locally
- Verified isolated SMTP tests can still be run separately
- Verified `TestYahooCheckByAPI` passes without relying on Yahoo's live signup endpoint

Related to #195