### PR TITLE
docs: correct the proxy documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,18 @@ If you want to disable catchAll checking, use the `DisableCatchAllCheck()` switc
 > Note: because most of the ISPs block outgoing SMTP requests through port 25 to prevent email spamming, the module will not perform SMTP checking by default. You can initialize the verifier with  `EnableSMTPCheck()`  to enable such capability if port 25 is usable, 
 > or use a socks proxy to connect over SMTP
 
+> Note: set `FromEmail()` and `HelloName()` before verifying at any volume. The defaults are
+> `user@example.org` and `localhost`, and `example.org` is reserved by RFC 2606, so a server
+> that validates the sender can reject the whole exchange before it ever considers the
+> address you asked about. Rejections of this kind arrive at `MAIL FROM` and name the sender
+> or the connecting host rather than the recipient, for example
+> `550 5.7.25 Forward-confirmed reverse DNS failed` or
+> `550 5.7.1 Service unavailable, Client host [...] blocked using Spamhaus`. Use a domain you
+> control, with a PTR record for the IP you connect from.
+
 ### Use a SOCKS5 proxy to verify email 
 
-Support setting a SOCKS5 proxy to verify the email, proxyURI should be in the format: `socks5://user:password@127.0.0.1:1080?timeout=5s`
+Support setting a SOCKS5 proxy to verify the email, proxyURI should be in the format: `socks5://user:password@127.0.0.1:1080`
 
 The protocol could be socks5, socks4 and socks4a.
 
@@ -128,7 +137,7 @@ var (
     verifier = emailverifier.
         NewVerifier().
         EnableSMTPCheck().
-    	Proxy("socks5://user:password@127.0.0.1:1080?timeout=5s")
+    	Proxy("socks5://user:password@127.0.0.1:1080")
 )
 
 func main() {
@@ -145,6 +154,37 @@ func main() {
 
 }
 ```
+
+Two things to know about the proxy:
+
+> **A query string in the proxy URI is ignored.** `golang.org/x/net/proxy` reads only the
+> scheme, credentials and host, so a `?timeout=5s` has no effect. Use `ConnectTimeout()` and
+> `OperationTimeout()` instead.
+
+> **DNS does not go through the proxy.** Only the connection to the mail server does, so MX
+> lookups still leave from the local machine. To route them through the proxy as well, dial
+> your DNS server over TCP through it — SOCKS5 carries TCP, and Go frames DNS over a
+> non-packet connection per RFC 7766:
+>
+> ```go
+> socksDialer, err := proxy.SOCKS5("tcp", "127.0.0.1:1080", nil, proxy.Direct)
+> if err != nil {
+>     return err
+> }
+> verifier = emailverifier.
+>     NewVerifier().
+>     EnableSMTPCheck().
+>     Proxy("socks5://127.0.0.1:1080").
+>     Resolver(&net.Resolver{
+>         PreferGo: true,
+>         Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+>             // ignore network, which may be "udp": SOCKS5 CONNECT carries TCP only
+>             return socksDialer.Dial("tcp", "8.8.8.8:53")
+>         },
+>     })
+> ```
+>
+> Each lookup opens a TCP connection through the proxy, so this costs more than plain UDP DNS.
 
 ### Use a custom DNS resolver
 

--- a/verifier.go
+++ b/verifier.go
@@ -224,8 +224,15 @@ func (v *Verifier) HelloName(domain string) *Verifier {
 }
 
 // Proxy sets a SOCKS5 proxy to verify the email,
-// proxyURI should be in the format: "socks5://user:password@127.0.0.1:1080?timeout=5s".
+// proxyURI should be in the format: "socks5://user:password@127.0.0.1:1080".
 // The protocol could be socks5, socks4 and socks4a.
+//
+// Only the scheme, credentials and host are read; a query string is ignored, so
+// a "?timeout=5s" has no effect. Use ConnectTimeout and OperationTimeout.
+//
+// The proxy carries the connection to the mail server, not DNS: MX lookups
+// still go out from the local machine. See Resolver for routing those through
+// the proxy too.
 func (v *Verifier) Proxy(proxyURI string) *Verifier {
 	v.proxyURI = proxyURI
 	return v


### PR DESCRIPTION
Three corrections to the proxy documentation, each verified against the code or against live servers.

## The proxy URI example advertised a parameter that does nothing

`socks5://user:password@127.0.0.1:1080?timeout=5s` appeared twice in the README and once in `Proxy`'s doc comment. `golang.org/x/net/proxy.FromURL` reads only the scheme, credentials and host — `RawQuery` and `timeout` appear nowhere in that package — so the parameter is silently discarded. Readers were configuring a timeout that never applied.

Removed from the examples, with a note pointing at `ConnectTimeout()` and `OperationTimeout()` instead.

## DNS was not mentioned at all

The proxy carries only the connection to the mail server. In `smtp.go` the MX lookup happens at `resolver.LookupMX` before `proxyURI` is consulted anywhere, which is not until `dialSMTP`. So MX queries still leave from the local machine, and configuring a proxy to hide the source does not hide them.

Now documented, and — since `Resolver()` landed in #191 — with the recipe for routing them through the proxy too, by dialling the DNS server over TCP through it. Verified end to end against a SOCKS5 proxy: `LookupMX` returns the correct 5 records for `gmail.com` and the proxy sees exactly one connection, to `8.8.8.8:53`.

## The default sender was undocumented

`FromEmail()` defaults to `user@example.org`, a domain reserved by RFC 2606, and `HelloName()` to `localhost`. A server that validates the sender can reject the whole exchange before it ever considers the address being checked.

Both rejections I hit while investigating are of that shape:

```
550 5.7.25 Forward-confirmed reverse DNS failed
550 5.7.1 Service unavailable, Client host [...] blocked using Spamhaus
```

Both arrive at `MAIL FROM` and name the sender or the connecting host, not the recipient, which is easy to misread as a problem with the address being verified. The note says to use a domain you control with a PTR record for the IP you connect from.

## Scope

Documentation only, plus the `Proxy` doc comment. No behaviour changes.

Refs #183, #154, #95 — these are the "proxy not working" reports. This does not fix anyone's proxy, but two of the three corrections describe traps those reporters could plausibly have hit, and the third explains why a rejection can name the sender rather than the address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
