### PR TITLE
fix: keep the partial SMTP result when the exchange fails

### DIFF
--- a/smtp.go
+++ b/smtp.go
@@ -7,7 +7,9 @@ import (
 	"math/rand"
 	"net"
 	"net/smtp"
+	"net/textproto"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -47,6 +49,12 @@ func (v *Verifier) CheckSMTP(domain, username string) (*SMTP, error) {
 	// Defer quit the SMTP connection
 	defer client.Close()
 
+	// We opened a connection and read the server's greeting, so the host is
+	// there whatever happens from here on. Recorded before EHLO and MAIL FROM
+	// so that a rejection at either -- which is about our sender, not about the
+	// host -- does not report the host as missing.
+	ret.HostExists = true
+
 	// Check by api when enabled and host recognized.
 	for _, apiVerifier := range v.apiVerifiers {
 		if apiVerifier.isSupported(strings.ToLower(mx.Host)) {
@@ -63,9 +71,6 @@ func (v *Verifier) CheckSMTP(domain, username string) (*SMTP, error) {
 	if err = client.Mail(v.fromEmail); err != nil {
 		return &ret, ParseSMTPError(err)
 	}
-
-	// Host exists if we've successfully formed a connection
-	ret.HostExists = true
 
 	// Default sets catch-all to true
 	ret.CatchAll = true
@@ -170,13 +175,47 @@ func newSMTPClient(domain, proxyURI string, resolver *net.Resolver, connectTimeo
 		case error:
 			errs = append(errs, r)
 			if len(errs) == len(mxRecords) {
-				return nil, nil, errs[0]
+				return nil, nil, preferredDialError(errs)
 			}
 		default:
 			return nil, nil, errors.New("Unexpected response dialing SMTP server")
 		}
 	}
 
+}
+
+// preferredDialError picks the most useful of the errors gathered while racing
+// the MX hosts.
+//
+// The hosts are dialled concurrently, so the first error to arrive is the one
+// that failed fastest -- typically a refused connection or a DNS miss. An error
+// carrying an SMTP reply took longer precisely because a server answered and
+// said why it was refusing us, which is what the caller needs. Returning the
+// first arrival systematically preferred the least informative one.
+func preferredDialError(errs []error) error {
+	for _, err := range errs {
+		if hasSMTPReply(err) {
+			return err
+		}
+	}
+	return errs[0]
+}
+
+// hasSMTPReply reports whether err carries a reply from an SMTP server, as
+// opposed to a network level failure.
+func hasSMTPReply(err error) bool {
+	var protoErr *textproto.Error
+	if errors.As(err, &protoErr) {
+		return true
+	}
+	// Errors that have already been rendered to a string keep the reply code
+	// at the front, so fall back to reading it from there.
+	s := err.Error()
+	if len(s) < 3 {
+		return false
+	}
+	code, convErr := strconv.Atoi(s[:3])
+	return convErr == nil && code >= 200 && code < 600
 }
 
 // dialSMTP is a timeout wrapper for smtp.Dial. It attempts to dial an

--- a/smtp_test.go
+++ b/smtp_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net"
+	"net/textproto"
 	"strings"
 	"sync/atomic"
 	"syscall"
@@ -229,4 +230,54 @@ func TestDialSMTP_ProxyBypassesCustomResolver(t *testing.T) {
 	assert.Nil(t, ret)
 	require.Error(t, err)
 	assert.False(t, called.Load())
+}
+
+func TestPreferredDialError(t *testing.T) {
+	network := errors.New("dial tcp 1.2.3.4:25: connect: connection refused")
+	dns := &net.DNSError{Err: "no such host", Name: "mx.example.invalid", IsNotFound: true}
+	reply := &textproto.Error{Code: 550, Msg: "5.7.1 Service unavailable, Client host blocked using Spamhaus."}
+	rendered := errors.New("421 4.7.0 Too many concurrent connections")
+
+	t.Run("prefers a server reply over a network failure", func(tt *testing.T) {
+		// the network failure arrives first because it fails fastest
+		assert.Same(tt, reply, preferredDialError([]error{network, reply}))
+	})
+
+	t.Run("prefers a server reply over a DNS failure", func(tt *testing.T) {
+		assert.Same(tt, reply, preferredDialError([]error{dns, reply}))
+	})
+
+	t.Run("recognises a reply that was already rendered to a string", func(tt *testing.T) {
+		assert.Same(tt, rendered, preferredDialError([]error{network, rendered}))
+	})
+
+	t.Run("falls back to the first error when no server replied", func(tt *testing.T) {
+		assert.Same(tt, network, preferredDialError([]error{network, dns}))
+	})
+
+	t.Run("single error", func(tt *testing.T) {
+		assert.Same(tt, network, preferredDialError([]error{network}))
+	})
+}
+
+func TestHasSMTPReply(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"textproto error", &textproto.Error{Code: 550, Msg: "no such user"}, true},
+		{"rendered reply", errors.New("452 4.5.3 Recipients belong to multiple regions"), true},
+		{"connection refused", errors.New("dial tcp 1.2.3.4:25: connect: connection refused"), false},
+		{"dns miss", &net.DNSError{Err: "no such host"}, false},
+		{"too short to carry a code", errors.New("no"), false},
+		{"leading digits that are not a reply code", errors.New("103.26.221.42 unreachable"), false},
+		{"no MX records", errors.New("No MX records found"), false},
+	}
+	for _, c := range cases {
+		test := c
+		t.Run(test.name, func(tt *testing.T) {
+			assert.Equal(tt, test.want, hasSMTPReply(test.err))
+		})
+	}
 }

--- a/verifier.go
+++ b/verifier.go
@@ -98,10 +98,15 @@ func (v *Verifier) Verify(email string) (*Result, error) {
 	ret.HasMxRecords = mx.HasMXRecord
 
 	smtp, err := v.CheckSMTP(syntax.Domain, syntax.Username)
+
+	// Kept whether or not the check succeeded. A failed exchange still says how
+	// far it got, which is the difference between a host that never answered and
+	// one that answered and refused our sender.
+	ret.SMTP = smtp
+
 	if err != nil {
 		return &ret, err
 	}
-	ret.SMTP = smtp
 	ret.Reachable = v.calculateReachable(smtp)
 
 	if v.gravatarCheckEnabled {


### PR DESCRIPTION
Three places threw away what the SMTP check had already established. Together they are why "the proxy does not work" reports have been hard to triage: the output cannot distinguish a host that never answered from one that answered and refused our sender.

## `HostExists` was recorded too late

It was set after `client.Hello` and `client.Mail`, so a rejection at either reported the host as missing — even though we had connected to it and read its greeting. Yahoo rejecting a sender with no reverse DNS produces exactly that: `550 5.7.25 Forward-confirmed reverse DNS failed` with `host_exists: false`, for a host that plainly exists.

Moved to just after the connection is established, where the existing comment ("Host exists if we've successfully formed a connection") already said it belonged.

## `Verify` discarded the result on the error path

Every `CheckSMTP` failure surfaced as `"smtp": null`, regardless of how far the exchange got. The assignment is now made whether or not the check succeeded — it applies to both paths, so it sits above the branch rather than being duplicated inside it.

## `newSMTPClient` returned the least informative error

When every MX host failed it returned `errs[0]`. The hosts are dialled concurrently, so that is whichever failed *fastest* — usually a refused connection or a DNS miss. An error carrying an SMTP reply took longer precisely because a server answered and said why it was refusing us, which is what the caller needs. The choice was systematically biased towards the least useful error.

`preferredDialError` now prefers an error that carries a reply, falling back to the first when none does.

## Verification

`preferredDialError` and `hasSMTPReply` are pure functions and are covered directly — 12 subtests, including a reply that has already been rendered to a string, a `*net.DNSError`, and a message beginning with an IP address that must not be mistaken for a reply code.

The other two changes only show up when a server accepts a connection and then rejects `EHLO` or `MAIL FROM`. That cannot be produced against live servers, because it depends on the runner's IP reputation — while testing this, Yahoo rejected `MAIL FROM` from my address and Gmail did not. Covering them properly needs a scriptable SMTP server, which is not in this PR.

Full suite passes with `-race`; `golangci-lint` reports no issues. Coverage 89.6% → 90.1%.

## Scope

No public API or JSON shape changes. `host_exists` becomes `true` in cases where it was previously `false`, and `smtp` is now populated on some error paths where it was `null` — both are corrections in the direction of reporting what actually happened.

Refs #183, #154, #95 — this does not fix anyone's proxy, but it is the information those reports needed and never got: whether the exchange failed at the connection, at the sender, or at the recipient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
