### PR TITLE
fix(build_metadata): stop update.sh publishing a broken list on failure

### DIFF
--- a/cmd/build_metadata/main.go
+++ b/cmd/build_metadata/main.go
@@ -14,7 +14,7 @@ import (
 // writeFile writes content to a file
 func writeFile(filePath string, data []byte) {
 	if _, err := os.Stat(filePath); os.IsNotExist(err) {
-		log.Fatalf("no such file: %s make sure running from the root of the repo directory", filePath)
+		log.Fatalf("no such file: %s make sure running from the cmd/build_metadata directory", filePath)
 	}
 
 	fmt.Printf("Writing new %s\n", filePath)

--- a/cmd/build_metadata/update.sh
+++ b/cmd/build_metadata/update.sh
@@ -1,33 +1,84 @@
 #!/usr/bin/env bash
 
 # description: for updating meta databases, including custom free domains and disposable domains.
+#
+# Refreshes the .txt lists only. The generated metadata_*.go files are built by
+# `go run main.go` in this directory, which runs this script first -- editing a
+# .txt list on its own leaves the compiled maps stale.
+#
+# Can be run from anywhere; paths resolve relative to the script.
 
-set -e
+set -euo pipefail
 export LC_ALL=C
 
-new=$(mktemp -t emailverifierXXX)
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+# A list this small means the fetch returned something other than the data. Both
+# sources are an order of magnitude larger; these floors exist to catch an empty
+# or truncated response, which would otherwise be published as "nothing is
+# disposable" and let every disposable domain through as a free one.
+readonly MIN_DISPOSABLE=50000
+readonly MIN_FREE=3000
+
+workdir=$(mktemp -d -t emailverifierXXXXXX)
+trap 'rm -rf "$workdir"' EXIT
+
+# --fail matters: without it curl exits 0 on an HTTP error and writes the error
+# body to stdout, which then gets published as domain data.
+fetch() {
+    curl --silent --show-error --fail --location "$1"
+}
+
+require_min_lines() {
+    local file=$1 min=$2 label=$3
+    local count
+    count=$(wc -l < "$file")
+    if [ "$count" -lt "$min" ]; then
+        echo "$label: got $count entries, expected at least $min -- refusing to publish" >&2
+        exit 1
+    fi
+    echo "$label: $count entries"
+}
 
 # 1. update disposable domains meta databases
-curl --silent https://raw.githubusercontent.com/tompec/disposable-email-domains/main/index.json | jq -r '.[]' > ./disposable.txt
+#    Sorted here rather than trusting the upstream order: step 3 hands this file
+#    to comm, which needs both inputs sorted and misreports if they are not.
+fetch https://raw.githubusercontent.com/tompec/disposable-email-domains/main/index.json \
+    | jq -r '.[]' \
+    | sort -u > "$workdir/disposable.txt"
+require_min_lines "$workdir/disposable.txt" "$MIN_DISPOSABLE" "disposable domains"
 
-# 2. update free domains meta databases,
-curl --silent https://raw.githubusercontent.com/Kikobeats/free-email-domains/refs/heads/master/domains.json | jq -r '.[]' > ./free.txt
-sources=$(cat ./free_domain_sources.txt)
-new=$(mktemp -t emailverifierXXX)
-for source in $sources; do
-    echo "$(curl --silent $source)" >> $new
-done;
+# 2. update free domains meta databases, from the primary source plus anything
+#    listed in free_domain_sources.txt
+fetch https://raw.githubusercontent.com/Kikobeats/free-email-domains/refs/heads/master/domains.json \
+    | jq -r '.[]' > "$workdir/free_raw.txt"
+while read -r source; do
+    [ -n "$source" ] || continue
+    fetch "$source" >> "$workdir/free_raw.txt"
+    # Not every source ends with a newline -- the tbrianjones list does not --
+    # so terminate each one explicitly, or its last domain merges with the
+    # first line of whatever is appended next. This is what the original
+    # script's echo "$(curl ...)" was doing. normalise drops the blank lines
+    # it leaves behind.
+    echo >> "$workdir/free_raw.txt"
+done < ./free_domain_sources.txt
 
-# 3. remove duplicates and sort
-tmp=$(mktemp -t emailverifierXXX)
-cat $new ./free.txt \
+# 3. normalise, remove duplicates and sort, then drop anything already known to
+#    be disposable. Whitespace is trimmed before blank lines are dropped so that
+#    a whitespace-only line does not survive as an empty entry.
+sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' "$workdir/free_raw.txt" \
     | sed '/^$/d' \
-    | sed '/./,$!d' \
-    | sed -e 's/^ *//' -e 's/ *$//' \
     | awk '{print tolower($0)}' \
-    | sort \
-    | uniq \
-    | comm -23 - ./disposable.txt > $tmp
-mv $tmp ./free.txt
+    | sort -u \
+    | comm -23 - "$workdir/disposable.txt" > "$workdir/free.txt"
+require_min_lines "$workdir/free.txt" "$MIN_FREE" "free domains"
+
+# 4. publish, only now that both lists are known good. Writing through the
+#    existing files keeps their permissions; mv would carry mktemp's 0600 over,
+#    leaving free.txt unreadable to other users in the working tree of whoever
+#    ran this. Never in the repository -- git records only the exec bit -- but
+#    it does happen locally.
+cat "$workdir/disposable.txt" > ./disposable.txt
+cat "$workdir/free.txt" > ./free.txt
 
 echo 'Complete Updating meta databases!'


### PR DESCRIPTION
`update.sh` overwrote `disposable.txt` and `free.txt` in place, before it knew whether the fetches had worked. Shell redirection truncates immediately, so any failure left the lists emptied or half written, and `set -e` then aborted — leaving the repo worse off than a clean failure would.

Worse, one failure mode did not abort at all. `curl --silent` exits 0 on an HTTP error and writes the error body to stdout, and without `pipefail` that status is discarded anyway. If a source returned valid but empty JSON, `jq -r '.[]'` exited 0 with no output, `disposable.txt` became empty, and the subtraction step subtracted nothing — so every disposable domain was published as a free one and the script reported success.

Reproduced against the real script with an empty upstream:

| | exit | disposable.txt | free.txt |
|---|---|---|---|
| before the run | — | 123324 | 4479 |
| original script | **0** | **0** | **14047** |
| this version | **1** | 123324 | 4479 |

```
disposable domains: got 0 entries, expected at least 50000 -- refusing to publish
```

### What changed

- **Fetch to a temp dir, publish last.** `mktemp -d` once with a `trap`, replacing three untracked temp files of which two leaked. Both lists are written only after every fetch and every guard has passed.
- **`set -euo pipefail`** and `curl --fail --show-error --location`, so an HTTP error is an error.
- **Minimum line counts** per list. A source returning nothing is the failure that silently inverts the meaning of the output, so it has to be caught by size.
- **Publish with `cat`, not `mv`,** so the target's permissions survive. `mv` carried `mktemp`'s 0600 across, leaving `free.txt` unreadable to other users in the working tree of whoever ran it. Never in the repository — git records only the exec bit — but it does happen locally.
- **`sort -u` before `comm`.** `comm` needs sorted inputs and exits 1 otherwise, which under the old script meant aborting after both lists had already been overwritten. The upstream order happened to be sorted, so this is a no-op on the data and removes the assumption.
- **`cd` to the script's own directory,** so it no longer writes wherever it was invoked from. Verified by running it from `/tmp`.
- **Terminate each fetched source with a newline.** Not every source ends with one — the tbrianjones list does not — so appending the next source merges two domains into a single line. The original `echo "$(curl ...)"` was doing this; a plain redirect is not.
- Dropped a dead `sed '/./,$!d'`, trimmed whitespace before dropping blank lines, and corrected `main.go`'s "run from the root of the repo" message, which is wrong — the tool must run from `cmd/build_metadata`.

No data and no library behaviour changes here; the lists are refreshed in the PRs stacked above.

---

Second of a five-PR stack. Based on #205, which it has no logical dependency on — that PR is simply below it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)