### PR TITLE
docs: add the missing v1.4.1 section to the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Unreleased
 * **Breaking**: Remove the non-functional Yahoo API verifier; `EnableAPIVerifier(YAHOO)` and the `YAHOO` constant are gone [#198](https://github.com/AfterShip/email-verifier/pull/198)
 * Fix: Yahoo API test panic no longer aborts the test suite [#196](https://github.com/AfterShip/email-verifier/pull/196)
 
+v1.4.1
+----------
+* Feature: Configurable timeouts via `ConnectTimeout()` and `OperationTimeout()` [#110](https://github.com/AfterShip/email-verifier/pull/110)
+* **Breaking**: Remove the Gmail API verifier; `EnableAPIVerifier(GMAIL)` and the `GMAIL` constant are gone [#113](https://github.com/AfterShip/email-verifier/pull/113)
+* Update the free domain sources and rebuild the generated metadata [#127](https://github.com/AfterShip/email-verifier/pull/127)
+* Update Dependencies
+
 v1.4.0
 ----------
 * Feature: Support Gmail&Yahoo SMTP check by API [#88](https://github.com/AfterShip/email-verifier/pull/88)


### PR DESCRIPTION
`v1.4.1` was released on 2024-09-12 and never made it into `CHANGELOG.md`, which jumps from `Unreleased` straight to `v1.4.0`. Its [GitHub release](https://github.com/AfterShip/email-verifier/releases/tag/v1.4.1) carries the auto-generated "What's Changed" list, so the content is recoverable — this puts it where anyone reading the changelog will look.

Contents taken from the release and checked against the commits rather than from the PR titles:

| | |
|---|---|
| #110 | added `ConnectTimeout()` and `OperationTimeout()` |
| #113 | removed the exported `GMAIL` constant along with the Gmail API verifier |
| #127 | refreshed the free domain sources and rebuilt the generated metadata |
| #114, #128 | dependency bumps, folded into "Update Dependencies" the way `v1.4.0` does |

#113 is marked `**Breaking**`, which it was — a compile break shipped in a patch release. Worth recording, because the Yahoo half of the same feature is going in the next release and the pair only reads coherently if both are there.

Found while checking what the next release's changelog should look like: renaming `Unreleased` would otherwise have produced `v1.5.0` sitting directly above `v1.4.0`, skipping a version that exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)