### PR TITLE
docs: cut v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Unreleased
 ----------
+
+v1.5.0
+----------
 * **Breaking**: Supported Go versions are now the three most recent releases, and `go.mod` requires the oldest of them, Go 1.25. The versions of `golang.org/x/net` and `golang.org/x/text` that fix [GO-2026-5026](https://pkg.go.dev/vuln/GO-2026-5026) and [GO-2026-5970](https://pkg.go.dev/vuln/GO-2026-5970) require it, and both were reachable from `Verify`, `CheckMX` and `CheckSMTP` through `idna.ToASCII` -- the second of them an infinite loop on caller-supplied input [#212](https://github.com/AfterShip/email-verifier/pull/212)
 * Fix: `AddDisposableDomains` no longer races the refresh that `EnableAutoUpdateDisposable()` schedules. Calling it from another goroutine while a refresh was running was a `fatal error: concurrent map iteration and map write`, which brings the process down and no `recover` can catch [#211](https://github.com/AfterShip/email-verifier/pull/211)
 * Fix: A small allowlist, `cmd/build_metadata/disposable_allowlist.txt`, keeps real providers the upstream list misclassifies out of the disposable set -- currently `hush.com`, `lavabit.com`, `mail2world.com`, `qmail.com`, `4x4man.com` and `alphafrau.de`. It applies to the generated list and to every `EnableAutoUpdateDisposable()` refresh, and since the free list is the free candidates minus the disposable one, these domains are now reported free rather than neither [#209](https://github.com/AfterShip/email-verifier/pull/209)


### PR DESCRIPTION
The ten entries under `Unreleased` become `v1.5.0`. `Unreleased` stays as an empty heading for the next cycle — it was only introduced in #198, so no release has had to deal with it before; this sets the pattern rather than following one.

### Why v1.5.0 and not v2

Three entries are marked breaking, and one of them is a compile break: the exported `YAHOO` constant is gone. Strict semver makes that a major, which in Go means moving the module path to `/v2` and every caller editing their imports.

The judgement is that the cost lands in the wrong place. The constant selected a verifier that had already stopped working — Yahoo removed the endpoint it relied on — so the break falls on callers of a feature that did not function, while `/v2` would fall on everyone. v1.4.1 set the precedent by removing the exported `GMAIL` constant in a *patch* release.

### After this merges

- tag `v1.5.0` and publish the release
- the release body groups the entries by what a reader has to do about them — what breaks a build, what changes an answer without needing a code change, what is new — rather than listing them in merge order. The changelog stays a flat log, which is what the file has always been
- GHSA-c2j9-vjcj-qrjc can then have `patched_versions` filled in

`main` was checked before this: builds on Go 1.25, `make test` passes at 90.2% coverage, `golangci-lint` reports nothing, and `govulncheck` finds no vulnerabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)