### PR TITLE
fix: report a refused address as unreachable when the catch-all probe is off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Unreleased
 ----------
 * Internal: Lint the whole repository rather than only changed lines, clearing 42 pre-existing findings; enable `usestdlibvars` and `intrange`; fix six error assertions that only checked that an error was non-nil [#217](https://github.com/AfterShip/email-verifier/pull/217)
+* Fix: `Reachable` is `no`, not `unknown`, when the mail server explicitly refuses the address and `DisableCatchAllCheck()` is in effect. `SMTP.CatchAll` was set before the catch-all probe ran and only ever cleared by a 550-class refusal, so with the probe disabled it stayed `true` and suppressed the verdict the address check had already produced [#220](https://github.com/AfterShip/email-verifier/pull/220)
 
 v1.5.0
 ----------

--- a/smtp.go
+++ b/smtp.go
@@ -26,24 +26,61 @@ type SMTP struct {
 	Disabled    bool `json:"disabled"`    // is the email blocked or disabled by the provider?
 }
 
+// catchAllOutcome records what the catch-all probe established. SMTP.CatchAll
+// cannot: it is also true when the probe never ran, and when the server replied
+// about itself rather than about the address.
+type catchAllOutcome int
+
+const (
+	// catchAllNotRun means the probe was disabled, or the exchange ended before it.
+	catchAllNotRun catchAllOutcome = iota
+	// catchAllAccepted means a random address was accepted, so the domain takes anything.
+	catchAllAccepted
+	// catchAllRefused means a random address was refused as non-existent, so the
+	// domain does not take just anything.
+	catchAllRefused
+	// catchAllInconclusive means the server replied, but about itself rather than
+	// about the address: a rate limit, a block, a temporary failure.
+	catchAllInconclusive
+)
+
+// catchAllFromResult reads an API verifier's flat result as a probe outcome.
+// The verifier reports a catch-all as a plain bool with none of our probing
+// behind it, so take it at face value: leaving the outcome at catchAllNotRun
+// would make a false CatchAll read as a refusal of the address itself.
+func catchAllFromResult(s *SMTP) catchAllOutcome {
+	if s != nil && s.CatchAll {
+		return catchAllAccepted
+	}
+	return catchAllRefused
+}
+
 // CheckSMTP performs an email verification on the passed domain via SMTP
 //   - the domain is the passed email domain
 //   - username is used to check the deliverability of specific email address,
 //
 // if server is catch-all server, username will not be checked
 func (v *Verifier) CheckSMTP(domain, username string) (*SMTP, error) {
+	res, _, err := v.checkSMTP(domain, username)
+	return res, err
+}
+
+// checkSMTP is CheckSMTP plus what the catch-all probe concluded. Verify needs
+// that to tell a domain which accepts every address from one we could not ask.
+func (v *Verifier) checkSMTP(domain, username string) (*SMTP, catchAllOutcome, error) {
 	if !v.smtpCheckEnabled {
-		return nil, nil
+		return nil, catchAllNotRun, nil
 	}
 
 	var ret SMTP
 	var err error
+	catchAll := catchAllNotRun
 	email := fmt.Sprintf("%s@%s", username, domain)
 
 	// Dial any SMTP server that will accept a connection
 	client, mx, err := newSMTPClient(domain, v.proxyURI, v.dnsResolver(), v.connectTimeout, v.operationTimeout)
 	if err != nil {
-		return &ret, ParseSMTPError(err)
+		return &ret, catchAll, ParseSMTPError(err)
 	}
 
 	// Defer quit the SMTP connection
@@ -58,18 +95,19 @@ func (v *Verifier) CheckSMTP(domain, username string) (*SMTP, error) {
 	// Check by api when enabled and host recognized.
 	for _, apiVerifier := range v.apiVerifiers {
 		if apiVerifier.isSupported(strings.ToLower(mx.Host)) {
-			return apiVerifier.check(domain, username)
+			res, err := apiVerifier.check(domain, username)
+			return res, catchAllFromResult(res), err
 		}
 	}
 
 	// Sets the HELO/EHLO hostname
 	if err = client.Hello(v.helloName); err != nil {
-		return &ret, ParseSMTPError(err)
+		return &ret, catchAll, ParseSMTPError(err)
 	}
 
 	// Sets the from email
 	if err = client.Mail(v.fromEmail); err != nil {
-		return &ret, ParseSMTPError(err)
+		return &ret, catchAll, ParseSMTPError(err)
 	}
 
 	// Default sets catch-all to true
@@ -80,6 +118,9 @@ func (v *Verifier) CheckSMTP(domain, username string) (*SMTP, error) {
 		// order to verify the existence of a catch-all and etc.
 		randomEmail := GenerateRandomEmail(domain)
 		if err = client.Rcpt(randomEmail); err != nil {
+			// The server said something, but not necessarily about the address.
+			// Only a refusal of the address itself rules a catch-all out.
+			catchAll = catchAllInconclusive
 			if e := ParseSMTPError(err); e != nil {
 				switch e.Message {
 				case ErrFullInbox:
@@ -90,31 +131,34 @@ func (v *Verifier) CheckSMTP(domain, username string) (*SMTP, error) {
 				// In most cases, this is because the recipient address does not exist.
 				case ErrServerUnavailable:
 					ret.CatchAll = false
+					catchAll = catchAllRefused
 				default:
 
 				}
 
 			}
+		} else {
+			catchAll = catchAllAccepted
 		}
 
 		// If the email server is a catch-all email server,
 		// no need to calibrate deliverable on a specific user
 		if ret.CatchAll {
-			return &ret, nil
+			return &ret, catchAll, nil
 		}
 	}
 
 	// If no username provided,
 	// no need to calibrate deliverable on a specific user
 	if username == "" {
-		return &ret, nil
+		return &ret, catchAll, nil
 	}
 
 	if err = client.Rcpt(email); err == nil {
 		ret.Deliverable = true
 	}
 
-	return &ret, nil
+	return &ret, catchAll, nil
 }
 
 // newSMTPClient generates a new available SMTP client

--- a/smtp_test.go
+++ b/smtp_test.go
@@ -280,3 +280,12 @@ func TestHasSMTPReply(t *testing.T) {
 		})
 	}
 }
+
+// The API-verifier branch returns before our own catch-all probe runs, so the
+// outcome has to come from what the verifier itself reported. Leaving it at
+// catchAllNotRun would turn a verifier's CatchAll: true into reachable "no".
+func TestCatchAllFromResult(t *testing.T) {
+	assert.Equal(t, catchAllAccepted, catchAllFromResult(&SMTP{CatchAll: true}))
+	assert.Equal(t, catchAllRefused, catchAllFromResult(&SMTP{CatchAll: false}))
+	assert.Equal(t, catchAllRefused, catchAllFromResult(nil))
+}

--- a/verifier.go
+++ b/verifier.go
@@ -94,7 +94,7 @@ func (v *Verifier) Verify(email string) (*Result, error) {
 	}
 	ret.HasMxRecords = mx.HasMXRecord
 
-	smtp, err := v.CheckSMTP(syntax.Domain, syntax.Username)
+	smtp, catchAll, err := v.checkSMTP(syntax.Domain, syntax.Username)
 
 	// Kept whether or not the check succeeded. A failed exchange still says how
 	// far it got, which is the difference between a host that never answered and
@@ -104,7 +104,7 @@ func (v *Verifier) Verify(email string) (*Result, error) {
 	if err != nil {
 		return &ret, err
 	}
-	ret.Reachable = v.calculateReachable(smtp)
+	ret.Reachable = v.calculateReachable(smtp, catchAll)
 
 	if v.gravatarCheckEnabled {
 		gravatar, err := v.CheckGravatar(email)
@@ -169,9 +169,8 @@ func (v *Verifier) DisableSMTPCheck() *Verifier {
 	return v
 }
 
-// EnableCatchAllCheck enables catchAll check by smtp
-// for most ISPs block outgoing catchAll requests through port 25, to prevent spam,
-// we don't check catchAll by default
+// EnableCatchAllCheck enables the catchAll check by smtp. It is on by default;
+// this undoes a previous DisableCatchAllCheck.
 func (v *Verifier) EnableCatchAllCheck() *Verifier {
 	v.catchAllCheckEnabled = true
 	return v
@@ -272,14 +271,22 @@ func (v *Verifier) OperationTimeout(timeout time.Duration) *Verifier {
 	return v
 }
 
-func (v *Verifier) calculateReachable(s *SMTP) string {
+// calculateReachable turns the SMTP observations into a verdict. Callers reach
+// it only from Verify, which always has a username: a syntactically valid
+// address cannot have an empty local part, so the address itself was always
+// probed unless the catch-all probe returned first.
+func (v *Verifier) calculateReachable(s *SMTP, catchAll catchAllOutcome) string {
 	if !v.smtpCheckEnabled {
 		return reachableUnknown
 	}
 	if s.Deliverable {
 		return reachableYes
 	}
-	if s.CatchAll {
+	// Deliberately not s.CatchAll, which is also true when the probe never ran
+	// or could not conclude. Only a probe that established a catch-all domain,
+	// or one that returned before the address was probed, leaves the address
+	// unverifiable; otherwise the address was refused and that is a definite no.
+	if catchAll == catchAllAccepted || catchAll == catchAllInconclusive {
 		return reachableUnknown
 	}
 	return reachableNo

--- a/verifier_test.go
+++ b/verifier_test.go
@@ -356,3 +356,34 @@ func TestVerifier_DefaultResolverReadAtCallTime(t *testing.T) {
 
 	assert.Same(t, replacement, v.dnsResolver())
 }
+
+// The catch-all probe's outcome, not SMTP.CatchAll, decides whether an address
+// is unverifiable. CatchAll is also true when the probe never ran and when it
+// could not conclude, which used to turn a definite refusal into "unknown".
+func TestCalculateReachable(t *testing.T) {
+	v := NewVerifier().EnableSMTPCheck()
+
+	cases := []struct {
+		name     string
+		smtp     SMTP
+		catchAll catchAllOutcome
+		want     string
+	}{
+		{"address accepted", SMTP{HostExists: true, Deliverable: true}, catchAllRefused, reachableYes},
+		{"address refused, probe ruled a catch-all out", SMTP{HostExists: true}, catchAllRefused, reachableNo},
+		{"address refused, probe disabled", SMTP{HostExists: true, CatchAll: true}, catchAllNotRun, reachableNo},
+		{"address accepted, probe disabled", SMTP{HostExists: true, CatchAll: true, Deliverable: true}, catchAllNotRun, reachableYes},
+		{"probe established a catch-all domain", SMTP{HostExists: true, CatchAll: true}, catchAllAccepted, reachableUnknown},
+		{"probe inconclusive, address never reached", SMTP{HostExists: true, CatchAll: true}, catchAllInconclusive, reachableUnknown},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(tt *testing.T) {
+			assert.Equal(tt, c.want, v.calculateReachable(&c.smtp, c.catchAll))
+		})
+	}
+}
+
+func TestCalculateReachable_SMTPCheckDisabled(t *testing.T) {
+	assert.Equal(t, reachableUnknown, NewVerifier().calculateReachable(nil, catchAllNotRun))
+}


### PR DESCRIPTION
Fixes #218.

**With `DisableCatchAllCheck()`, an address the server explicitly refuses now comes back `reachable: "no"` instead of `"unknown"`. Callers on the defaults see no change.**

## Why the old answer was wrong

`SMTP.CatchAll == true` means one of three things, and `calculateReachable` read all three as "cannot tell":

| `CatchAll: true` because | was the address checked? | `unknown` justified? |
|---|---|---|
| the probe accepted a random address | no, and pointlessly — the domain takes anything | yes |
| the probe replied about itself, not the address | no, the exchange returned early | yes |
| **the probe never ran** | **yes, and it was refused** | **no** |

`smtp.go:76` sets the flag before any probe and only a 550-class refusal clears it, so under `DisableCatchAllCheck()` it is always `true`. The address is still sent to `RCPT` — the early return that would skip it lives *inside* the probe block — so the evidence was already in `Deliverable`. A meaningless flag vetoed it.

## The fix

Decide on what the probe concluded instead:

```diff
-	if s.CatchAll {
+	if catchAll == catchAllAccepted || catchAll == catchAllInconclusive {
 		return reachableUnknown
 	}
 	return reachableNo
```

`catchAllOutcome` is `not-run` / `accepted` / `refused` / `inconclusive`, set where the existing switch already classifies the reply. An unexported `checkSMTP` carries it and `CheckSMTP` drops it, so no exported signature moves — and it is not a field on `SMTP`, which #202 established is breaking.

Also drops a doc comment claiming catchAll is off by default; `NewVerifier` sets it `true`.

## Demonstrated end to end

Against a local server that refuses every `RCPT` with `550 5.1.1`, the two configurations now agree:

```
probe on    reachable="no"   CatchAll=false  Deliverable=false
probe off   reachable="no"   CatchAll=true   Deliverable=false     (was "unknown")
```

Only the meaningless flag differs. That is what `DisableCatchAllCheck()` should cost: one fewer `RCPT`, not every definite answer.

<details>
<summary>Why only that configuration is affected, and the full state table</summary>

`catchAllCheckEnabled` is set `false` nowhere but `DisableCatchAllCheck()`, and `NewVerifier` sets it `true`. Of the eight `return` statements in `checkSMTP`, three carry a non-nil error so `Verify` returns before computing a verdict; one is the API-verifier branch, reporting `accepted` or `refused`; one is the SMTP-check-off path; and one sits inside the probe block, so it reports `accepted` or `inconclusive`. That leaves the `username == ""` return — unreachable from `Verify`, since a syntactically valid address cannot have an empty local part — and the function's last line. Both require the probe block to have been skipped.

On the native path the outcome and `SMTP.CatchAll` are coupled: `refused` clears the flag, while `not-run` and the two early-return outcomes leave it set. So of the sixteen input combinations only seven arise, and exactly one changes answer:

| `smtpCheckEnabled` | probe outcome | `SMTP.CatchAll` | `Deliverable` | `Reachable` on main | `Reachable` here |
|---|---|---|---|---|---|
| false | not-run | — (`SMTP` is nil) | — | `unknown` | `unknown` |
| true | **not-run** | true | **false** | `unknown` | **`no`** |
| true | not-run | true | true | `yes` | `yes` |
| true | accepted | true | false | `unknown` | `unknown` |
| true | refused | false | false | `no` | `no` |
| true | refused | false | true | `yes` | `yes` |
| true | inconclusive | true | false | `unknown` | `unknown` |

That coupling holds only on the native path. `catchAllFromResult` derives the outcome from whatever an API verifier reports, so that branch can pair any `SMTP` with `accepted` or `refused` — including `accepted` with `Deliverable: true`, which the native path cannot produce. Both logics answer `yes` there, `Deliverable` being checked first. No caller can reach that branch today: `smtpAPIVerifier` is unexported and `EnableAPIVerifier` registers nothing. It is handled anyway, because the doc comment invites vendors and leaving the outcome at `not-run` would read a verifier's `CatchAll: true` as a refusal of the address.

</details>

## What this does not fix

A `no` is only as good as the refusal behind it, and `client.Rcpt`'s error is still discarded — so "no such user" and "your IP is blocked" are indistinguishable, and a policy rejection reads as a false `no`. Unchanged here, and not new: the default path has always answered `no` on a bare refusal. Recording the address probe's outcome too is the real answer to #183.

`inconclusive` keeps returning `unknown` by design: the early return means the address was never probed. Continuing past an inconclusive probe is #72; reporting catch-all as its own verdict is #219.

## Verification

- Table test over all seven reachable states, plus one for `catchAllFromResult`
- **Mutation-tested**: reverting to `if s.CatchAll` fails exactly one case
- End-to-end as above; `golangci-lint run` clean; 74 tests pass under `-race`

The network-dependent tests open real SMTP connections and were left to CI.
