### PR TITLE
feat: expose the RFC 3463 enhanced status code from SMTP replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Unreleased
 ----------
 * Internal: Lint the whole repository rather than only changed lines, clearing 42 pre-existing findings; enable `usestdlibvars` and `intrange`; fix six error assertions that only checked that an error was non-nil [#217](https://github.com/AfterShip/email-verifier/pull/217)
 * Fix: `Reachable` is `no`, not `unknown`, when the mail server explicitly refuses the address and `DisableCatchAllCheck()` is in effect. `SMTP.CatchAll` was set before the catch-all probe ran and only ever cleared by a 550-class refusal, so with the probe disabled it stayed `true` and suppressed the verdict the address check had already produced [#220](https://github.com/AfterShip/email-verifier/pull/220)
+* Feature: `LookupError.EnhancedCode()` exposes the RFC 3463 enhanced status code a server sent, for example `5.1.1`. The class digit is dependable, the subject digit is not a verdict -- Yandex answers an unknown recipient with the same `5.7.1` that Apple uses to say our sending IP is blocklisted -- and it is empty for the providers that send no code at all [#222](https://github.com/AfterShip/email-verifier/pull/222)
 
 v1.5.0
 ----------

--- a/error.go
+++ b/error.go
@@ -1,7 +1,10 @@
 package emailverifier
 
 import (
+	"errors"
 	"fmt"
+	"net/textproto"
+	"regexp"
 	"strconv"
 	"strings"
 )
@@ -35,6 +38,9 @@ type LookupError struct {
 	// errors.As to reach the underlying *net.DNSError, *net.OpError or
 	// *textproto.Error instead of having to match on Details.
 	cause error
+
+	// enhanced is the RFC 3463 enhanced status code the server sent, if any.
+	enhanced string
 }
 
 // newLookupError creates a new LookupError reference and returns it
@@ -60,8 +66,51 @@ func (e *LookupError) Unwrap() error {
 	return e.cause
 }
 
+// EnhancedCode returns the RFC 3463 enhanced status code the server sent, for
+// example "5.7.1", or an empty string if it sent none. Several large providers
+// send none, so callers must handle the empty case rather than read it as a
+// classification.
+//
+// The class digit is dependable -- 2 success, 4 transient, 5 permanent -- but
+// the subject is evidence, not a verdict: providers disagree with the registry
+// and with each other over which subject an unknown recipient gets.
+func (e *LookupError) EnhancedCode() string {
+	if e == nil {
+		return ""
+	}
+	return e.enhanced
+}
+
 func (e *LookupError) Error() string {
 	return fmt.Sprintf("%s : %s", e.Message, e.Details)
+}
+
+// enhancedCodeInReplyPattern matches the code in a reply that reaches us
+// flattened into one string: right after the reply code, so that the IP
+// addresses and diagnostic identifiers these replies carry are not mistaken for
+// one.
+var enhancedCodeInReplyPattern = regexp.MustCompile(`^[245][0-9]{2}[ -]\s*([245]\.[0-9]{1,3}\.[0-9]{1,3})\b`)
+
+// enhancedCodeInMsgPattern matches it where textproto keeps it: Code has been
+// split off, so the enhanced code starts Msg.
+var enhancedCodeInMsgPattern = regexp.MustCompile(`^\s*([245]\.[0-9]{1,3}\.[0-9]{1,3})\b`)
+
+// enhancedCodeOf extracts the enhanced status code from an SMTP reply. It starts
+// textproto.Error's Msg; Error() renders that with %q, which puts the code behind
+// a quote, so the rendered form serves only replies that reach us already
+// flattened -- ParseSMTPError is exported and takes those too.
+func enhancedCodeOf(err error) string {
+	var tp *textproto.Error
+	if errors.As(err, &tp) {
+		if m := enhancedCodeInMsgPattern.FindStringSubmatch(tp.Msg); len(m) > 1 {
+			return m[1]
+		}
+		return ""
+	}
+	if m := enhancedCodeInReplyPattern.FindStringSubmatch(err.Error()); len(m) > 1 {
+		return m[1]
+	}
+	return ""
 }
 
 // ParseSMTPError receives an MX Servers response message
@@ -75,11 +124,13 @@ func ParseSMTPError(err error) *LookupError {
 	if err == nil {
 		return nil
 	}
-	if le := parseSMTPError(err); le != nil {
-		return le.withCause(err)
+	le := parseSMTPError(err)
+	if le == nil {
+		errStr := err.Error()
+		le = newLookupError(errStr, errStr)
 	}
-	errStr := err.Error()
-	return newLookupError(errStr, errStr).withCause(err)
+	le.enhanced = enhancedCodeOf(err)
+	return le.withCause(err)
 }
 
 func parseSMTPError(err error) *LookupError {

--- a/error_test.go
+++ b/error_test.go
@@ -3,6 +3,7 @@ package emailverifier
 import (
 	"errors"
 	"net"
+	"net/textproto"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -221,4 +222,178 @@ func TestParseError_basicErr_blocked(t *testing.T) {
 
 	assert.Equal(t, ErrBlocked, le.Message)
 	assert.Equal(t, err.Error(), le.Details)
+}
+
+// Replies captured 2026-09-10 by driving the exchange directly, so the table
+// doubles as a record of what enhanced status codes look like in the wild.
+// Verbatim, session identifiers included; only our egress IP is replaced.
+//
+// Each is a *textproto.Error because that is what net/smtp returns. A table of
+// plain strings passed while the feature was broken for every real reply.
+func TestParseSMTPError_EnhancedCode(t *testing.T) {
+	cases := []struct {
+		name     string
+		err      error
+		enhanced string
+	}{
+		{
+			// Multi-line: textproto joins the lines with \n, each repeating the code.
+			name: "gmail, recipient unknown, RCPT",
+			err: &textproto.Error{Code: 550, Msg: "5.1.1 The email account that you tried to reach does not exist. Please try\n" +
+				"5.1.1 double-checking the recipient's email address for typos or\n" +
+				"5.1.1 unnecessary spaces. For more information, go to\n" +
+				"5.1.1  https://support.google.com/mail/?p=NoSuchUser 41be03b00d2f7-cc4c687ec03si136868a12.335 - gsmtp"},
+			enhanced: "5.1.1",
+		},
+		{
+			// X.5.x for an unknown mailbox, not X.1.x: the subject is not a verdict.
+			name:     "microsoft, recipient unknown, RCPT",
+			err:      &textproto.Error{Code: 550, Msg: "5.5.0 Requested action not taken: mailbox unavailable (S2017062302). [SJ1PEPF000037A2.namprd04.prod.outlook.com 2026-09-10T17:20:46.631Z 08DF0B1332F1DE15]"},
+			enhanced: "5.5.0",
+		},
+		{
+			// Rejected at MAIL FROM: no recipient had been named.
+			name:     "yahoo, sender fails FCrDNS, MAIL FROM",
+			err:      &textproto.Error{Code: 550, Msg: "5.7.25 Forward-confirmed reverse DNS failed tnmpmscs"},
+			enhanced: "5.7.25",
+		},
+		{
+			name:     "zoho, recipient unknown, RCPT",
+			err:      &textproto.Error{Code: 550, Msg: "5.1.1 User does not exist - <rcpwt0gy04lubc4qmkpppxr128xgnaef@zoho.com>"},
+			enhanced: "5.1.1",
+		},
+		{
+			// No enhanced code despite a 550 about the recipient. Egress IP replaced.
+			name:     "qq sends no enhanced code, RCPT",
+			err:      &textproto.Error{Code: 550, Msg: "Mailbox not found. http://service.mail.qq.com/detail/122/169 [MAW77ic63OtZB8WdcrvY/gIHPvUvsXupE8bE5roaPk+ab2Lvf59Ok0394SdGexrgVA== IP: 198.51.100.1]"},
+			enhanced: "",
+		},
+		{
+			name:     "netease sends no enhanced code, RCPT",
+			err:      &textproto.Error{Code: 550, Msg: "User not found: lyta8y5m8nenxwdkg2vybjw2n2cjg602@163.com"},
+			enhanced: "",
+		},
+		{
+			// Earlier run. The only transient reply captured, and for a real mailbox.
+			name:     "microsoft, transient, RCPT",
+			err:      &textproto.Error{Code: 452, Msg: "4.5.3 Recipients belong to multiple regions ATTR38 [AMS1EPF0000008F.eurprd05.prod.outlook.com]"},
+			enhanced: "4.5.3",
+		},
+		{
+			// Carries a bare IPv4 address the pattern must not mistake for a code.
+			name:     "sender blocklisted, reply contains an IP address",
+			err:      &textproto.Error{Code: 550, Msg: "5.7.1 Service unavailable, Client host [198.51.100.1] blocked using Spamhaus."},
+			enhanced: "5.7.1",
+		},
+		{
+			// X.7.x -- reserved for policy -- for an unknown recipient. With the
+			// case below, one code meaning two opposite things.
+			name:     "yandex, recipient unknown, answered with 5.7.1",
+			err:      &textproto.Error{Code: 550, Msg: "5.7.1 No such user! 1789063127-kwTVGUHdeiE0-huj9x1Wr"},
+			enhanced: "5.7.1",
+		},
+		{
+			// The same code, meaning our IP is blocklisted. No recipient was judged.
+			name:     "apple, sender blocklisted, answered with 5.7.1",
+			err:      &textproto.Error{Code: 550, Msg: "5.7.1 Mail from IP 198.51.100.1 was rejected due to listing in Spamhaus SBL. For details please see http://www.spamhaus.org/query/bl?ip=198.51.100.1"},
+			enhanced: "5.7.1",
+		},
+		{
+			// The default HelloName rejected at EHLO. 501 is not a code
+			// parseSMTPError switches on; see the Message test below.
+			name:     "fastmail rejects EHLO localhost",
+			err:      &textproto.Error{Code: 501, Msg: "5.7.1 <localhost>: Helo command rejected: HELO string 'localhost' not accepted, Use a real hostname/ip"},
+			enhanced: "5.7.1",
+		},
+		{
+			// Same rejection, but Hello returned nil and it surfaced at RCPT.
+			name:     "tuta rejects EHLO localhost, surfacing at RCPT",
+			err:      &textproto.Error{Code: 504, Msg: "5.5.2 <localhost>: Helo command rejected: need fully-qualified hostname"},
+			enhanced: "5.5.2",
+		},
+		{
+			// Refused at the greeting: multi-line, no enhanced code.
+			name: "united internet refuses the connection",
+			err: &textproto.Error{Code: 554, Msg: "gmx.net (mxgmx009) Nemesis ESMTP Service not available\n" +
+				"No SMTP service\n" +
+				"IP address is block listed.\n" +
+				"For explanation visit https://postmaster.gmx.net/en/case?c=r0303&i=ip&v=198.51.100.1&r=1N6a0i-1wlEnE2roU-012Max"},
+			enhanced: "",
+		},
+		{
+			// The default FromEmail: example.org publishes v=spf1 -all.
+			name:     "aliyun rejects the default sender on spf",
+			err:      &textproto.Error{Code: 554, Msg: "Reject by behaviour spam at Rcpt State(Connection IP address:198.51.100.1)ANTISPAM_BAT[01201311R846a, maildocker-behaviorspam033068209079]: spf check failedCONTINUE"},
+			enhanced: "",
+		},
+		{
+			// A rate limit wearing a 550, with no enhanced code to say so.
+			name:     "sina rate-limits with a 550",
+			err:      &textproto.Error{Code: 550, Msg: "Too many recipients."},
+			enhanced: "",
+		},
+		{
+			name:     "dns failure carries no reply",
+			err:      &net.DNSError{Err: "no such host", Name: "icloud.com", IsNotFound: true},
+			enhanced: "",
+		},
+		{
+			// Code and Msg are separate fields: a reply code we cannot parse says
+			// nothing about Msg. ParseSMTPError is exported and takes any error.
+			name:     "unparseable reply code, enhanced code still read",
+			err:      &textproto.Error{Code: 1234, Msg: "5.1.1 no such user"},
+			enhanced: "5.1.1",
+		},
+		{
+			name:     "3xx reply, no enhanced code of a class we recognise",
+			err:      &textproto.Error{Code: 354, Msg: "3.0.0 start mail input"},
+			enhanced: "",
+		},
+		{
+			name:     "connection failure, rendered as a string",
+			err:      errors.New("dial tcp 1.2.3.4:25: connect: connection refused"),
+			enhanced: "",
+		},
+		{
+			name:     "reply rendered as a string",
+			err:      errors.New("550 5.1.1 does not exist"),
+			enhanced: "5.1.1",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(tt *testing.T) {
+			le := ParseSMTPError(c.err)
+			require.NotNil(tt, le)
+			assert.Equal(tt, c.enhanced, le.EnhancedCode())
+		})
+	}
+}
+
+func TestLookupError_EnhancedCodeNilSafe(t *testing.T) {
+	var le *LookupError
+	assert.Empty(t, le.EnhancedCode())
+}
+
+// Pins current behaviour rather than endorsing it: Details, and Message for a
+// reply code parseSMTPError does not switch on, are built from the %q rendering,
+// so callers see escaped quotes and a literal \n. Details is serialised, so this
+// reaches everyone. Changing it wants its own review; this stops it drifting.
+func TestParseSMTPError_RenderedReplyLeaksIntoMessageAndDetails(t *testing.T) {
+	t.Run("Details always carries the rendered reply", func(tt *testing.T) {
+		le := ParseSMTPError(&textproto.Error{Code: 550, Msg: "Too many recipients."})
+		assert.Equal(tt, ErrServerUnavailable, le.Message)
+		assert.Equal(tt, `550 "Too many recipients."`, le.Details)
+	})
+
+	t.Run("an unswitched reply code leaves it in Message too", func(tt *testing.T) {
+		le := ParseSMTPError(&textproto.Error{Code: 501, Msg: "5.7.1 <localhost>: Helo command rejected"})
+		assert.Equal(tt, `501 "5.7.1 <localhost>: Helo command rejected"`, le.Message)
+		assert.Equal(tt, le.Message, le.Details)
+	})
+
+	t.Run("EnhancedCode is unaffected, being read from Msg", func(tt *testing.T) {
+		le := ParseSMTPError(&textproto.Error{Code: 501, Msg: "5.7.1 <localhost>: Helo command rejected"})
+		assert.Equal(tt, "5.7.1", le.EnhancedCode())
+	})
 }


### PR DESCRIPTION
Adds `LookupError.EnhancedCode()`, returning the RFC 3463 enhanced status code a server sent — `5.1.1`, `5.7.25` — or an empty string when it sent none. Nothing else changes: no classification, no verdict, no existing field.

## Reading it from the right place

`net/smtp` reports replies as `*textproto.Error`, which splits the reply code into `Code` and leaves the rest in `Msg` — so the enhanced code starts `Msg`. `Error()` is a rendering, not the reply:

```go
// go1.27.1  net/textproto/textproto.go:44
return fmt.Sprintf("%03d %q", e.Code, e.Msg)
```

`%q` puts the code behind a quote and escapes the newlines of a multi-line reply, so nothing anchored at the reply code finds it there. That was a real bug in the first draft of this branch: the feature returned `""` for every reply it was built for while 71 lines of tests passed, because the table was built from hand-written strings rather than the type the code path produces.

Two patterns, because the two inputs are shaped differently — in `Msg` the code is at the start; in a reply that reaches us already flattened it follows the reply code. An earlier draft rebuilt `Code` and `Msg` into one string so a single pattern could serve both, which made the extraction depend on `Code` agreeing with that pattern: a constraint the protocol does not impose and the rebuild invented. `ParseSMTPError` is exported, so a caller can hand it an error with any `Code` at all.

Every case now carries a `*textproto.Error`. Reading the rendered string instead fails eleven of the twenty; rebuilding `Code` and `Msg` fails the one that pins their independence.

## Why classification is not changed here

The obvious next step is to replace the eight keywords in `parseSMTPError` with the RFC 3463 subject digit. Captures from nineteen provider infrastructures, one per MX operator say that does not work — "this recipient does not exist" comes back as:

| answered as | providers |
|---|---|
| `5.1.1` | Gmail, Zoho, Naver, Daum |
| `5.5.0` | Microsoft |
| **`5.7.1`** | **Yandex** — the subject reserved for security and policy, and the same code Apple uses to say our IP is on the Spamhaus SBL |
| no enhanced code at all | QQ, NetEase, Sina |

Only the class digit held everywhere: `4` transient, `5` permanent.

The stage a rejection arrives at is more informative than the code, but it is not sufficient either. A refusal at the greeting, at `EHLO` or at `MAIL FROM` cannot be about a recipient — none has been named — and Yahoo, Fastmail and United Internet all rejected there. But Apple and Tuta rejected *at* `RCPT` and still said nothing about the recipient: one about our IP being on the Spamhaus SBL, the other still complaining about `EHLO`.

Changing verdicts needs more than this PR provides. #221 tracks the rest.

## On the record: the library's own defaults draw rejections

Not fixed here, but captured so it is documented — `defaultHelloName` is `localhost` and `defaultFromEmail` is `user@example.org`:

- **Fastmail** — `501 5.7.1 ... HELO string 'localhost' not accepted`
- **Tuta** — `504 5.5.2 ... need fully-qualified hostname`
- **Aliyun** — `554 ... spf check failed`, because `example.org` publishes `v=spf1 -all`

## Pinned, not fixed

A second test records where the `%q` rendering still shows: `Details` always carries it (`550 "Too many recipients."`), and so does `Message` for a reply code `parseSMTPError` does not switch on — the `501` and `504` above. `Details` is a serialised field, so this reaches every consumer. Fixing it changes visible output and wants its own review; the test is there so it cannot change unnoticed.

Also: the `ENHANCEDSTATUSCODES` EHLO keyword is not a usable predictor. Zoho and Yahoo send codes without advertising it; Mail.ru, Sina and Aliyun advertise nothing and send nothing. Callers handle the empty string rather than testing for support, and the doc comment says so.

## Verification

- 20 cases, the captured replies each as the `*textproto.Error` the code path produces
- **Mutation-tested** two ways: reading the rendered string fails eleven cases; rebuilding `Code`+`Msg` fails the independence case
- `golangci-lint run`: `0 issues`; `go build ./...` and `go vet ./...` clean; 76 tests pass under `-race`

Captures are verbatim, including the providers' own session identifiers, so the table doubles as a record of what these replies look like. Our egress IP is replaced throughout with `198.51.100.1` (RFC 5737). The network-dependent tests were left to CI.
