### PR TITLE
fix: classify a reply by what it says, not by the rendering of it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased
 * Internal: Lint the whole repository rather than only changed lines, clearing 42 pre-existing findings; enable `usestdlibvars` and `intrange`; fix six error assertions that only checked that an error was non-nil [#217](https://github.com/AfterShip/email-verifier/pull/217)
 * Fix: `Reachable` is `no`, not `unknown`, when the mail server explicitly refuses the address and `DisableCatchAllCheck()` is in effect. `SMTP.CatchAll` was set before the catch-all probe ran and only ever cleared by a 550-class refusal, so with the probe disabled it stayed `true` and suppressed the verdict the address check had already produced [#220](https://github.com/AfterShip/email-verifier/pull/220)
 * Feature: `LookupError.EnhancedCode()` exposes the RFC 3463 enhanced status code a server sent, for example `5.1.1`. The class digit is dependable, the subject digit is not a verdict -- Yandex answers an unknown recipient with the same `5.7.1` that Apple uses to say our sending IP is blocklisted -- and it is empty for the providers that send no code at all [#222](https://github.com/AfterShip/email-verifier/pull/222)
+* Fix: `LookupError.Details`, and `Message` for a reply code the classifier does not recognise, carry the SMTP reply as it arrived rather than Go's `%q` rendering of it, which added quotes and escaped the newlines of a multi-line reply. A transient 4xx is no longer read as a permanent statement about the recipient [#223](https://github.com/AfterShip/email-verifier/pull/223)
 
 v1.5.0
 ----------

--- a/error.go
+++ b/error.go
@@ -95,6 +95,31 @@ var enhancedCodeInReplyPattern = regexp.MustCompile(`^[245][0-9]{2}[ -]\s*([245]
 // split off, so the enhanced code starts Msg.
 var enhancedCodeInMsgPattern = regexp.MustCompile(`^\s*([245]\.[0-9]{1,3}\.[0-9]{1,3})\b`)
 
+// blockedKeywords mark a reply as a refusal of us rather than of the address.
+// One list: the 550 branch and parseBasicErr had drifted apart.
+var blockedKeywords = []string{
+	"spamhaus",
+	"proofpoint",
+	"cloudmark",
+	"banned",
+	"blacklisted",
+	"blocked",
+	"block list",
+	"denied",
+}
+
+// replyText returns the server's reply as it arrived. textproto.Error renders
+// with %q, which wraps the text in quotes and escapes a multi-line reply's
+// newlines, so Error() is a debug form rather than the reply. Errors carrying no
+// reply of their own fall back to it.
+func replyText(err error) string {
+	var tp *textproto.Error
+	if errors.As(err, &tp) {
+		return fmt.Sprintf("%03d %s", tp.Code, tp.Msg)
+	}
+	return err.Error()
+}
+
 // enhancedCodeOf extracts the enhanced status code from an SMTP reply. It starts
 // textproto.Error's Msg; Error() renders that with %q, which puts the code behind
 // a quote, so the rendered form serves only replies that reach us already
@@ -126,7 +151,7 @@ func ParseSMTPError(err error) *LookupError {
 	}
 	le := parseSMTPError(err)
 	if le == nil {
-		errStr := err.Error()
+		errStr := replyText(err)
 		le = newLookupError(errStr, errStr)
 	}
 	le.enhanced = enhancedCodeOf(err)
@@ -134,7 +159,7 @@ func ParseSMTPError(err error) *LookupError {
 }
 
 func parseSMTPError(err error) *LookupError {
-	errStr := err.Error()
+	errStr := replyText(err)
 
 	// Verify the length of the error before reading nil indexes
 	if len(errStr) < 3 {
@@ -147,11 +172,12 @@ func parseSMTPError(err error) *LookupError {
 		return parseBasicErr(err)
 	}
 
-	// If the status code is above 400 there was an error and we should return it
 	if status > 400 {
-		// Don't return an error if the error contains anything about the address
-		// being undeliverable
-		if insContains(errStr,
+		// Only a permanent reply can be read as a statement about the address: a
+		// 4xx says the server could not answer now, whatever its text mentions.
+		// Bounded above too, since ParseSMTPError is exported and a code outside
+		// SMTP's classes says nothing about a recipient either.
+		if status >= 500 && status < 600 && insContains(errStr,
 			"undeliverable",
 			"does not exist",
 			"may not exist",
@@ -185,15 +211,7 @@ func parseSMTPError(err error) *LookupError {
 		case 503:
 			return newLookupError(ErrNeedMAILBeforeRCPT, errStr)
 		case 550: // 550 is Mailbox Unavailable - usually undeliverable, ref: https://blog.mailtrap.io/550-5-1-1-rejected-fix/
-			if insContains(errStr,
-				"spamhaus",
-				"proofpoint",
-				"cloudmark",
-				"banned",
-				"blacklisted",
-				"blocked",
-				"block list",
-				"denied") {
+			if insContains(errStr, blockedKeywords...) {
 				return newLookupError(ErrBlocked, errStr)
 			}
 			return newLookupError(ErrServerUnavailable, errStr)
@@ -215,17 +233,11 @@ func parseSMTPError(err error) *LookupError {
 // parseBasicErr parses a basic MX record response and returns
 // a more understandable LookupError
 func parseBasicErr(err error) *LookupError {
-	errStr := err.Error()
+	errStr := replyText(err)
 
 	// Return a more understandable error
 	switch {
-	case insContains(errStr,
-		"spamhaus",
-		"proofpoint",
-		"cloudmark",
-		"banned",
-		"blocked",
-		"denied"):
+	case insContains(errStr, blockedKeywords...):
 		return newLookupError(ErrBlocked, errStr)
 	case insContains(errStr, "timeout"):
 		return newLookupError(ErrTimeout, errStr)

--- a/error_test.go
+++ b/error_test.go
@@ -375,25 +375,71 @@ func TestLookupError_EnhancedCodeNilSafe(t *testing.T) {
 	assert.Empty(t, le.EnhancedCode())
 }
 
-// Pins current behaviour rather than endorsing it: Details, and Message for a
-// reply code parseSMTPError does not switch on, are built from the %q rendering,
-// so callers see escaped quotes and a literal \n. Details is serialised, so this
-// reaches everyone. Changing it wants its own review; this stops it drifting.
-func TestParseSMTPError_RenderedReplyLeaksIntoMessageAndDetails(t *testing.T) {
-	t.Run("Details always carries the rendered reply", func(tt *testing.T) {
-		le := ParseSMTPError(&textproto.Error{Code: 550, Msg: "Too many recipients."})
-		assert.Equal(tt, ErrServerUnavailable, le.Message)
-		assert.Equal(tt, `550 "Too many recipients."`, le.Details)
+// A 4xx says the server could not answer now. Its text may still mention the
+// recipient -- Microsoft's transient reply for a real mailbox does -- so the
+// keyword check that reads a reply as a statement about the address has to be
+// confined to permanent replies, or a rate limit is filed as a refusal.
+func TestParseSMTPError_TransientRepliesReachTheSwitch(t *testing.T) {
+	cases := []struct {
+		name    string
+		err     error
+		message string
+	}{
+		{"452 mentioning the recipient", &textproto.Error{Code: 452, Msg: "4.5.3 user unknown, try later"}, ErrTooManyRCPT},
+		{"421 mentioning the recipient", &textproto.Error{Code: 421, Msg: "4.7.0 mailbox does not exist right now"}, ErrTryAgainLater},
+		{"450 mentioning the recipient", &textproto.Error{Code: 450, Msg: "4.2.0 no mailbox here yet"}, ErrMailboxBusy},
+		{"the same phrase at 5xx still reads as the address", &textproto.Error{Code: 550, Msg: "5.1.1 user unknown"}, ErrServerUnavailable},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(tt *testing.T) {
+			assert.Equal(tt, c.message, ParseSMTPError(c.err).Message)
+		})
+	}
+}
+
+// One blocklist keyword list. The 550 branch and parseBasicErr had drifted
+// apart, so whether a phrase counted depended on the reply code.
+func TestParseSMTPError_BlockedKeywordsAreOneList(t *testing.T) {
+	for _, kw := range blockedKeywords {
+		t.Run(kw, func(tt *testing.T) {
+			// 550 is in the switch; 501 is not and falls to parseBasicErr.
+			for _, code := range []int{550, 501} {
+				le := ParseSMTPError(&textproto.Error{Code: code, Msg: "5.7.1 host is " + kw})
+				assert.Equal(tt, ErrBlocked, le.Message, "reply code %d", code)
+			}
+		})
+	}
+}
+
+// Details is meant to be the reply. textproto renders with %q, which is a debug
+// form: it adds quotes the server never sent and turns the newlines of a
+// multi-line reply into a literal \n.
+func TestParseSMTPError_DetailsIsTheReplyNotItsRendering(t *testing.T) {
+	t.Run("multi-line keeps its lines", func(tt *testing.T) {
+		le := ParseSMTPError(&textproto.Error{Code: 550, Msg: "5.1.1 line one\n5.1.1 line two"})
+		assert.Equal(tt, "550 5.1.1 line one\n5.1.1 line two", le.Details)
 	})
 
-	t.Run("an unswitched reply code leaves it in Message too", func(tt *testing.T) {
+	t.Run("the server's own quotes survive unescaped", func(tt *testing.T) {
+		le := ParseSMTPError(&textproto.Error{Code: 550, Msg: `5.7.1 see "docs"`})
+		assert.Equal(tt, `550 5.7.1 see "docs"`, le.Details)
+	})
+
+	// Message is built from the same text for a reply code parseSMTPError does
+	// not switch on, so it changes with Details rather than separately.
+	t.Run("an unswitched reply code carries the reply in Message too", func(tt *testing.T) {
 		le := ParseSMTPError(&textproto.Error{Code: 501, Msg: "5.7.1 <localhost>: Helo command rejected"})
-		assert.Equal(tt, `501 "5.7.1 <localhost>: Helo command rejected"`, le.Message)
+		assert.Equal(tt, "501 5.7.1 <localhost>: Helo command rejected", le.Message)
 		assert.Equal(tt, le.Message, le.Details)
 	})
 
-	t.Run("EnhancedCode is unaffected, being read from Msg", func(tt *testing.T) {
-		le := ParseSMTPError(&textproto.Error{Code: 501, Msg: "5.7.1 <localhost>: Helo command rejected"})
-		assert.Equal(tt, "5.7.1", le.EnhancedCode())
+	t.Run("a code outside SMTP's classes is not read as a recipient verdict", func(tt *testing.T) {
+		le := ParseSMTPError(&textproto.Error{Code: 600, Msg: "6.1.1 user unknown"})
+		assert.Equal(tt, "600 6.1.1 user unknown", le.Message)
+	})
+
+	t.Run("errors carrying no reply are unchanged", func(tt *testing.T) {
+		err := &net.DNSError{Err: "no such host", Name: "x.invalid", IsNotFound: true}
+		assert.Equal(tt, err.Error(), ParseSMTPError(err).Details)
 	})
 }


### PR DESCRIPTION
Two fixes in `parseSMTPError`, both about where the reply text comes from and which part of it may be read as a statement about the recipient.

## `Details` carried a rendering, not the reply

`textproto.Error` formats with `%q`, which adds quotes the server never sent and escapes a multi-line reply's newlines. `Details` is serialised, so every consumer saw that:

```
before   550 "5.1.1 line one\n5.1.1 line two"
after    550 5.1.1 line one
         5.1.1 line two
```

`replyText` reads `Code` and `Msg` — the fields textproto parsed the reply into — falling back to `Error()` for errors that carry no reply of their own: dial failures, DNS failures, and the flattened replies the exported `ParseSMTPError` also takes. Those are unchanged.

## A 4xx is not a statement about the address

The keyword check for `"user unknown"`, `"does not exist"` and eight more phrases ran before the switch, on every failure class. A transient reply naming the recipient was therefore answered `ErrServerUnavailable`, which `CheckSMTP` reads as evidence the domain is not a catch-all — and then skips probing the address. Now confined to 5xx.

A defect by the RFC's definition of the class rather than an observed one: the only 4xx among the nineteen providers probed for #222 is Microsoft's `452 4.5.3 Recipients belong to multiple regions`, which matches none of the phrases and already reached the switch. Such a reply now lands on `Too many recipients` — no better a description of its text. What changes is that it is no longer a *permanent* verdict about the address.

## And one keyword list instead of two

The 550 branch knew `blacklisted` and `block list`; `parseBasicErr` did not. So `501 blacklisted host` was reported verbatim while the same phrase at 550 was reported as blocked. One `blockedKeywords` now, walked by a test against a reply code inside the switch and one outside.

## What did not change

5xx classification. Two changes that would have altered it were tried and dropped, both turning on the keyword lists being precise when they are not:

- letting a blocklist phrase outrank a recipient phrase reclassified `550 ... Recipient address rejected: access denied` as blocked. That is Postfix's wording for an unknown recipient, and it only matched because our list carries the very broad `"denied"`
- widening the bound to `>= 400` looked like an off-by-one tidy, but put 400 through keyword matching

The override of 551 through 554 by recipient phrases is left alone for the same reason. No verdict changes either: a 4xx refusal of the address still answers `no`, because `CheckSMTP` discards that error before anything can see the class. #221 has the map.

## Verification

- Tests for each fix. The `%q` pin #222 added failed here, as intended, and is replaced by tests for the behaviour that supersedes it
- `golangci-lint run`: `0 issues`; `go build ./...` and `go vet ./...` clean; 67 `error.go` cases and 78 offline tests pass under `-race`

The network-dependent tests were left to CI.
